### PR TITLE
Feature/support url styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,85 @@ More information in [Amazon documentation](https://docs.aws.amazon.com/cli/lates
 
 The functionality implemented by this library requires that the user has some permissions defined by an IAM policy.
 
-- Health-check functionality performs a HEAD bucket operation, requiring allowed `s3:HeadBucket` for all resources.
+- Health-check functionality performs a HEAD bucket operation, requiring allowed `s3:ListBucket` for all resources.
 
 - Get functionality requires allowed `s3:GetObject` for the objects under the hierarchy you want to allow (e.g. `my-bucket/prefix/*`).
 
 - Upload (PUT) functionality requires allowed `s3:PutObject` for the objects under the hierarchy you want to allow (e.g. `my-bucket/prefix/*`).
 
-- Multipart upload functionality requires allowed `s3:PutObject`, `s3:GetObject`, `s3:AbortMultipartUpload`, `s3:ListMultipartUploadParts` for objects under the hierarcy you want to allow (e.g. `my-bucket/prefix/*`); and `s3:ListBucketMultipartUploads` for the bucket (e.g. `my-bucket`).
+- Multipart upload functionality requires allowed `s3:PutObject`, `s3:GetObject`, `s3:AbortMultipartUpload`, `s3:ListMultipartUploadParts` for objects under the hierarchy you want to allow (e.g. `my-bucket/prefix/*`); and `s3:ListBucketMultipartUploads` for the bucket (e.g. `my-bucket`).
 
 Please, see our [terraform repository](https://github.com/ONSdigital/dp-setup/tree/develop/terraform) for more information.
 
-#### Usage
+#### S3 Client Usage
 
-You can access AWS S3 creating a new client using the New() function in client.go providing the right region. Please, note that you will only be able to see S3 buckets created in a particular region using a client accessing that region.
+You can access AWS S3 to get objects and do multipart uploads by creating a new client using the `NewClient()` function in client.go with the right region and bucketName,
+or `NewClientWithSession()` if you already have an established AWS session.
+Please, note that you will only be able to see S3 buckets created in a particular region using a client accessing that region.
 
 ```
-s3cli := s3client.New(<region>)
-s3cli.Get(<url>)
+s3cli := s3client.NewClient(<region>, <bucket>, <hasUserDefinedPSK>)
+s3cli.Get(<S3ObjectKey>)
+...
 ```
+
+```
+s3cli := NewClientWithSession(<bucket>, <hasUserDefinedPSK>, <awsSession>)
+s3cli.Get(<S3ObjectKey>)
+...
+```
+
+#### Uploader Usage
+
+You can access AWS S3 to upload (PUT) objects by creating a new uploader using the `NewUploader()` function in uploader.go with the right region and bucketName,
+or `NewUploaderWithSession()` if you already have an established AWS session.
+Please, note that you will only be able to see S3 buckets created in a particular region using a client accessing that region.
+
+```
+s3Uploader := s3client.NewUploader(<region>, <bucket>, <hasUserDefinedPSK>)
+s3Uploader.Upload(<input>)
+...
+```
+
+```
+s3Uploader := NewUploaderWithSession(<bucket>, <hasUserDefinedPSK>, <awsSession>)
+s3Uploader.Upload(<input>)
+...
+```
+
+#### URL Usage
+
+S3Url is a structure intended to be used for S3 URL string manipulation in its different formats. To create a new structure you need to provide region, bucketName and object key,
+and optionally the scheme:
+
+```
+s3Url, err := func NewURL(<region>, <bucket>, <s3ObjcetKey>)
+s3Url, err := func NewURLWithScheme(<scheme>, <region>, <bucket>, <s3ObjcetKey>)
+```
+
+If you want to parse a URL into an s3Url object, you can use `ParseURL()` method, providing the format style:
+
+```
+s3Url, err := ParseURL(<rawURL>, <URLStyle>)
+```
+
+Once you have a valid s3Url object, you can obtain the URL string representation in the required format style by calling `String()` method:
+
+```
+str, err := s3Url.String(<URLStyle>)
+```
+
+##### Valid URL format Styles
+
+The following URL styles are supported:
+
+- PathStyle: `https://s3-eu-west-1.amazonaws.com/myBucket/my/s3/object/key`
+- GlobalPathStyle: `https://s3.amazonaws.com/myBucket/my/s3/object/key`
+- VirtualHostedStyle: `https://myBucket.s3-eu-west-1.amazonaws.com/my/s3/object/key`
+- GlobalVirtualHostedStyle: `https://myBucket.s3.amazonaws.com/my/s3/object/key`
+- AliasVirtualHostedStyle: '`https://myBucket/my/s3/object/key`
+
+More information in [S3 official documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html)
 
 ### Health package
 

--- a/client.go
+++ b/client.go
@@ -320,20 +320,20 @@ func (cli *S3) doGetFromS3URL(rawURL string, style URLStyle, psk []byte) (io.Rea
 	}
 
 	// Validate that URL and client bucket names match
-	if s3Url.BucketName() != cli.bucketName {
+	if s3Url.BucketName != cli.bucketName {
 		return nil, &ErrUnexpectedBucket{
-			ExpectedBucketName: cli.bucketName, BucketName: s3Url.BucketName()}
+			ExpectedBucketName: cli.bucketName, BucketName: s3Url.BucketName}
 	}
 
 	// Validate that URL and client regions match, if URL provides one
-	if len(s3Url.Region()) > 0 && s3Url.Region() != cli.region {
-		return nil, &ErrUnexpectedRegion{ExpectedRegion: cli.region, Region: s3Url.Region()}
+	if len(s3Url.Region) > 0 && s3Url.Region != cli.region {
+		return nil, &ErrUnexpectedRegion{ExpectedRegion: cli.region, Region: s3Url.Region}
 	}
 
 	if psk == nil {
-		return cli.Get(s3Url.Key())
+		return cli.Get(s3Url.Key)
 	}
-	return cli.GetWithPSK(s3Url.Key(), psk)
+	return cli.GetWithPSK(s3Url.Key, psk)
 }
 
 // Get returns an io.ReadCloser instance for the given path (inside the bucket configured for this client).

--- a/client_test.go
+++ b/client_test.go
@@ -50,7 +50,7 @@ func TestGet(t *testing.T) {
 
 		Convey("GetFromS3URL called with a valid global URL returns an io.Reader with the expected payload", func() {
 			validGlobalURL := fmt.Sprintf("s3://%s/%s", bucket, objKey)
-			ret, err := s3Cli.GetFromS3URL(validGlobalURL, s3client.StyleAliasVirtualHosted)
+			ret, err := s3Cli.GetFromS3URL(validGlobalURL, s3client.AliasVirtualHostedStyle)
 			So(err, ShouldBeNil)
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(ret)
@@ -65,7 +65,7 @@ func TestGet(t *testing.T) {
 
 		Convey("GetFromS3URL called with a valid regional URL returns an io.Reader with the expected payload", func() {
 			validRegionalURL := fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", region, bucket, objKey)
-			ret, err := s3Cli.GetFromS3URL(validRegionalURL, s3client.StylePath)
+			ret, err := s3Cli.GetFromS3URL(validRegionalURL, s3client.PathStyle)
 			So(err, ShouldBeNil)
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(ret)
@@ -80,21 +80,21 @@ func TestGet(t *testing.T) {
 
 		Convey("GetFromS3URL called with a valid global URL with the wrong bucket returns ErrUnexpectedBucket", func() {
 			wrongBucketGlobalURL := fmt.Sprintf("s3://%s/%s", "wrongBucket", objKey)
-			_, err := s3Cli.GetFromS3URL(wrongBucketGlobalURL, s3client.StyleAliasVirtualHosted)
+			_, err := s3Cli.GetFromS3URL(wrongBucketGlobalURL, s3client.AliasVirtualHostedStyle)
 			So(err, ShouldResemble, &s3client.ErrUnexpectedBucket{ExpectedBucketName: bucket, BucketName: "wrongBucket"})
 			So(len(sdkMock.GetObjectCalls()), ShouldEqual, 0)
 		})
 
 		Convey("GetFromS3URL called with a valid regional URL with the wrong region returns ErrUnexpectedBucket", func() {
 			wrongRegionRegionalURL := fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", "wrongRegion", bucket, objKey)
-			_, err := s3Cli.GetFromS3URL(wrongRegionRegionalURL, s3client.StylePath)
+			_, err := s3Cli.GetFromS3URL(wrongRegionRegionalURL, s3client.PathStyle)
 			So(err, ShouldResemble, &s3client.ErrUnexpectedRegion{ExpectedRegion: region, Region: "wrongRegion"})
 			So(len(sdkMock.GetObjectCalls()), ShouldEqual, 0)
 		})
 
 		Convey("GetFromS3URL called with a malformed URL returns error", func() {
 			malformedURL := "This%Url%Is%Malformed"
-			_, err := s3Cli.GetFromS3URL(malformedURL, s3client.StyleAliasVirtualHosted)
+			_, err := s3Cli.GetFromS3URL(malformedURL, s3client.AliasVirtualHostedStyle)
 			So(err, ShouldResemble, &url.Error{Op: "parse", URL: malformedURL, Err: url.EscapeError("%Ur")})
 			So(len(sdkMock.GetObjectCalls()), ShouldEqual, 0)
 		})
@@ -138,7 +138,7 @@ func TestGetWithPSK(t *testing.T) {
 
 		Convey("GetFromS3URLWithPSK called with a valid global URL returns an io.Reader with the expected payload", func() {
 			validGlobalURL := fmt.Sprintf("s3://%s/%s", bucket, objKey)
-			ret, err := s3Cli.GetFromS3URLWithPSK(validGlobalURL, s3client.StyleAliasVirtualHosted, psk)
+			ret, err := s3Cli.GetFromS3URLWithPSK(validGlobalURL, s3client.AliasVirtualHostedStyle, psk)
 			So(err, ShouldBeNil)
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(ret)

--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,18 @@ import (
 	"fmt"
 )
 
+// ErrUnexpectedRegion if a request tried to access an unexpected region
+type ErrUnexpectedRegion struct {
+	Region         string
+	ExpectedRegion string
+}
+
+// Error returns the error message with the requested and expected regions
+func (e *ErrUnexpectedRegion) Error() string {
+	return fmt.Sprintf("Unexpected region: %s. This S3 client is configured with region %s",
+		e.Region, e.ExpectedRegion)
+}
+
 // ErrUnexpectedBucket if a request tried to access an unexpected bucket
 type ErrUnexpectedBucket struct {
 	BucketName         string

--- a/url.go
+++ b/url.go
@@ -11,16 +11,16 @@ import (
 type URLStyle int
 
 // Possible S3 URL format styles, as defined in https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
-// PathStyle example: 'https://s3-eu-west-1.amazonaws.com/myBucket/my/s3/object/key'
-// GlobalPathStyle example: 'https://s3.amazonaws.com/myBucket/my/s3/object/key'
-// VirtualHostedStyle example: 'https://myBucket.s3-eu-west-1.amazonaws.com/my/s3/object/key'
-// GlobalVirtualHostedStyle example: 'https://myBucket.s3.amazonaws.com/my/s3/object/key'
-// AliasVirtualHostedStyle example: 'https://myBucket/my/s3/object/key'
 const (
+	// PathStyle example: 'https://s3-eu-west-1.amazonaws.com/myBucket/my/s3/object/key'
 	PathStyle = iota
+	// GlobalPathStyle example: 'https://s3.amazonaws.com/myBucket/my/s3/object/key'
 	GlobalPathStyle
+	// VirtualHostedStyle example: 'https://myBucket.s3-eu-west-1.amazonaws.com/my/s3/object/key'
 	VirtualHostedStyle
+	// GlobalVirtualHostedStyle example: 'https://myBucket.s3.amazonaws.com/my/s3/object/key'
 	GlobalVirtualHostedStyle
+	// AliasVirtualHostedStyle example: 'https://myBucket/my/s3/object/key'
 	AliasVirtualHostedStyle
 )
 

--- a/url.go
+++ b/url.go
@@ -1,35 +1,245 @@
 package s3client
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 )
 
-// NewURL create a new instance of URL from a virtual-hosted-style URL
-// e.g. 'https://bucktName/ObjectKey'
-func NewURL(rawURL string) (*URL, error) {
+// URLStyle is the type to define the URL style iota enumeration corresponding an S3 url (path, virtualHosted, etc)
+type URLStyle int
 
-	url, err := url.Parse(rawURL)
+// Possible S3 URL styles
+const (
+	StylePath = iota
+	StyleGlobalPath
+	StyleVirtualHosted
+	StyleGlobalVirtualHosted
+	StyleAliasVirtualHosted
+)
+
+var urlStyles = []string{"Path", "GlobalPath", "VirtualHosted", "GlobalVirtualHosted", "AliasVirtualHosted"}
+
+// Values of the format styles
+func (style URLStyle) String() string {
+	return urlStyles[style]
+}
+
+// S3Url represents an S3 URL with bucketName, key and region (optional). This struct is
+// intended to be used for S3 URL string manipulation/translation in its possible format styles.
+type S3Url struct {
+	region     string
+	bucketName string
+	key        string
+}
+
+// Region returns the region defined by the url
+func (s3Url *S3Url) Region() string {
+	return s3Url.region
+}
+
+// BucketName returns the bucket name defined by the url
+func (s3Url *S3Url) BucketName() string {
+	return s3Url.bucketName
+}
+
+// Key returns the object key defined by the url
+func (s3Url *S3Url) Key() string {
+	return s3Url.key
+}
+
+// String returns the S3 URL string in the requested format style.
+// Possible formats are defined in https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
+// PathStyle example: 'https://s3-eu-west-1.amazonaws.com/myBucket/my/s3/object/key'
+// GlobalPathStyle example: 'https://s3.amazonaws.com/myBucket/my/s3/object/key'
+// VirtualHostedStyle example: 'https://myBucket.s3-eu-west-1.amazonaws.com/my/s3/object/key'
+// GlobalVirtualHostedStyle example: 'https://myBucket.s3.amazonaws.com/my/s3/object/key'
+// AliasVirtualHostedStyle example: 'https://myBucket/my/s3/object/key'
+func (s3Url *S3Url) String(style URLStyle) (string, error) {
+	switch style {
+	case StylePath:
+		if len(s3Url.region) == 0 {
+			return "", errors.New("Path style format requires a region")
+		}
+		url := "https://s3-%s.amazonaws.com/%s/%s"
+		return fmt.Sprintf(url, s3Url.region, s3Url.bucketName, s3Url.key), nil
+	case StyleGlobalPath:
+		url := "https://s3.amazonaws.com/%s/%s"
+		return fmt.Sprintf(url, s3Url.bucketName, s3Url.key), nil
+	case StyleVirtualHosted:
+		if len(s3Url.region) == 0 {
+			return "", errors.New("Virtual-hosted style format requires a region")
+		}
+		url := "https://%s.s3-%s.amazonaws.com/%s"
+		return fmt.Sprintf(url, s3Url.bucketName, s3Url.region, s3Url.key), nil
+	case StyleGlobalVirtualHosted:
+		url := "https://%s.s3.amazonaws.com/%s"
+		return fmt.Sprintf(url, s3Url.bucketName, s3Url.key), nil
+	case StyleAliasVirtualHosted:
+		url := "https://%s/%s"
+		return fmt.Sprintf(url, s3Url.bucketName, s3Url.key), nil
+	}
+	return "", errors.New("Undefined style")
+}
+
+// ParseURL creates an S3Url struct from the provided rawULR and format style
+func ParseURL(rawURL string, style URLStyle) (*S3Url, error) {
+	switch style {
+	case StylePath:
+		return ParsePathStyleURL(rawURL)
+	case StyleGlobalPath:
+		return ParseGlobalPathStyleURL(rawURL)
+	case StyleVirtualHosted:
+		return ParseVirtualHostedURL(rawURL)
+	case StyleGlobalVirtualHosted:
+		return ParseGlobalVirtualHostedURL(rawURL)
+	case StyleAliasVirtualHosted:
+		return ParseAliasVirtualHostedURL(rawURL)
+	}
+	return nil, errors.New("Undefined style")
+}
+
+// ParsePathStyleURL creates an S3Url struct from the provided path-style url string
+// Example: 'https://s3-eu-west-1.amazonaws.com/myBucket/my/s3/object/key'
+func ParsePathStyleURL(pathStyleURL string) (*S3Url, error) {
+
+	url, err := url.Parse(pathStyleURL)
 	if err != nil {
 		return nil, err
 	}
 
-	return &URL{
-		URL: url,
+	region := strings.TrimSuffix(strings.TrimPrefix(url.Host, "s3-"), ".amazonaws.com")
+	if len(region) == 0 {
+		return nil, fmt.Errorf("wrong region in path-style url: %s", pathStyleURL)
+	}
+
+	bucketName, key, err := parsePath(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewURL(region, bucketName, key)
+}
+
+// ParseGlobalPathStyleURL creates an S3Url struct from the provided global-path-style url string
+// Example: 'https://s3.amazonaws.com/myBucket/my/s3/object/key'
+func ParseGlobalPathStyleURL(gpURL string) (*S3Url, error) {
+	url, err := url.Parse(gpURL)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketName, key, err := parsePath(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewURL("", bucketName, key)
+}
+
+func parsePath(url *url.URL) (bucketName string, key string, err error) {
+	splittedPath := strings.Split(url.Path, "/")
+	if len(splittedPath) < 3 {
+		return "", "", fmt.Errorf("could not find bucket or filename in file path-style url %s", url.String())
+	}
+
+	bucketName = splittedPath[1]
+	if len(bucketName) == 0 {
+		return "", "", fmt.Errorf("missing bucket name in path-style url %s", url.String())
+	}
+
+	key = strings.TrimPrefix(url.Path, fmt.Sprintf("/%s/", bucketName))
+	if len(key) == 0 {
+		return "", "", fmt.Errorf("missing s3 object key in path-style url %s", url.String())
+	}
+	return
+}
+
+// ParseVirtualHostedURL creates an S3Url struct from the provided virtual-hosted-style url string
+// Example: 'https://myBucket.s3-eu-west-1.amazonaws.com/my/s3/object/key'
+func ParseVirtualHostedURL(vhURL string) (*S3Url, error) {
+	url, err := url.Parse(vhURL)
+	if err != nil {
+		return nil, err
+	}
+
+	splittedHost := strings.Split(url.Host, ".")
+	if len(splittedHost) < 4 {
+		return nil, fmt.Errorf("could not find bucket name or region in virtual-hosted-style url %s", vhURL)
+	}
+
+	region := strings.TrimPrefix(splittedHost[len(splittedHost)-3], "s3-")
+	if len(region) == 0 {
+		return nil, fmt.Errorf("wrong region in virtual-hosted-style url: %s", vhURL)
+	}
+
+	bucketName := strings.TrimSuffix(url.Host, fmt.Sprintf(".s3-%s.amazonaws.com", region))
+	if len(bucketName) == 0 {
+		return nil, fmt.Errorf("wrong bucket name in virtual-hosted-style url: %s", vhURL)
+	}
+
+	key := strings.TrimPrefix(url.Path, "/")
+	if len(key) == 0 {
+		return nil, fmt.Errorf("wrong key in virtual-hosted-style url: %s", vhURL)
+	}
+
+	return NewURL(region, bucketName, key)
+}
+
+// ParseGlobalVirtualHostedURL creates an S3Url struct from the provided global-virtual-hosted-style url string
+// Example: 'https://myBucket.s3.amazonaws.com/my/s3/object/key'
+func ParseGlobalVirtualHostedURL(gvhURL string) (*S3Url, error) {
+	url, err := url.Parse(gvhURL)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketName := strings.TrimSuffix(url.Host, ".s3.amazonaws.com")
+	if len(bucketName) == 0 {
+		return nil, fmt.Errorf("wrong bucketName in global virtual hosted style url: %s", gvhURL)
+	}
+
+	key := strings.TrimPrefix(url.Path, "/")
+	if len(key) == 0 {
+		return nil, fmt.Errorf("wrong key in global virtual hosted style url: %s", gvhURL)
+	}
+
+	return NewURL("", bucketName, key)
+}
+
+// ParseAliasVirtualHostedURL creates an S3Url struct from the provided dns-alias-virtual-hosted-style url string
+// Example: 'https://myBucket/my/s3/object/key'
+func ParseAliasVirtualHostedURL(avhURL string) (*S3Url, error) {
+	url, err := url.Parse(avhURL)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketName := url.Host
+	if len(bucketName) == 0 {
+		return nil, fmt.Errorf("wrong bucketName in DNS-alias-virtual-hosted-style url: %s", avhURL)
+	}
+
+	key := strings.TrimPrefix(url.Path, "/")
+	if len(key) == 0 {
+		return nil, fmt.Errorf("wrong key in global virtual hosted style url: %s", avhURL)
+	}
+
+	return NewURL("", bucketName, key)
+}
+
+// NewURL instantiates a new S3Url struct with the provided region, bucket name and object key
+func NewURL(region, bucketName, key string) (*S3Url, error) {
+	if len(bucketName) == 0 {
+		return nil, errors.New("bucketName required")
+	}
+	if len(key) == 0 {
+		return nil, errors.New("key required")
+	}
+	return &S3Url{
+		region:     region,
+		bucketName: bucketName,
+		key:        key,
 	}, nil
-}
-
-// URL represents a fully qualified S3 URL that includes the bucket name.
-type URL struct {
-	*url.URL
-}
-
-// BucketName returns the bucket name from the URL.
-func (url *URL) BucketName() string {
-	return url.Host
-}
-
-// Path returns the file path (S3 key) from the URL.
-func (url *URL) Path() string {
-	return strings.TrimPrefix(url.URL.Path, "/")
 }

--- a/url_test.go
+++ b/url_test.go
@@ -1,39 +1,262 @@
 package s3client_test
 
 import (
+	"fmt"
 	"testing"
 
-	s3 "github.com/ONSdigital/dp-s3"
+	s3client "github.com/ONSdigital/dp-s3"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestSpec(t *testing.T) {
+func TestFullyDefinedUrl(t *testing.T) {
 
 	const expectedBucketName = "csv-bucket"
-	const expectedFilePath = "dir1/test-file.csv"
-	const rawURL = "s3://" + expectedBucketName + "/" + expectedFilePath
+	const expectedKey = "dir1/test-file.csv"
+	const expectedRegion = "eu-west-1"
 
-	Convey("Given an instance of s3.URL with a valid fully qualified S3 URL", t, func() {
-
-		s3URL, err := s3.NewURL(rawURL)
+	Convey("Given an instance of S3Url with valid bucketName, region and object key", t, func() {
+		s3Url, err := s3client.NewURL(expectedRegion, expectedBucketName, expectedKey)
 		So(err, ShouldBeNil)
 
-		Convey("When the bucket name is requested", func() {
-
-			bucketName := s3URL.BucketName()
-
-			Convey("It should provide the expected value", func() {
-				So(bucketName, ShouldEqual, expectedBucketName)
-			})
+		Convey("Getters return the expected values", func() {
+			So(s3Url.Region(), ShouldEqual, expectedRegion)
+			So(s3Url.BucketName(), ShouldEqual, expectedBucketName)
+			So(s3Url.Key(), ShouldEqual, expectedKey)
 		})
 
-		Convey("When the file path is requested", func() {
-
-			filePath := s3URL.Path()
-
-			Convey("It should provide the expected value", func() {
-				So(filePath, ShouldEqual, expectedFilePath)
-			})
+		Convey("Path style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", expectedRegion, expectedBucketName, expectedKey)
+			urlStr, err := s3Url.String(s3client.StylePath)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
 		})
+
+		Convey("Global Path style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://s3.amazonaws.com/%s/%s", expectedBucketName, expectedKey)
+			urlStr, err := s3Url.String(s3client.StyleGlobalPath)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
+		})
+
+		Convey("Virtual hosted style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://%s.s3-%s.amazonaws.com/%s", expectedBucketName, expectedRegion, expectedKey)
+			urlStr, err := s3Url.String(s3client.StyleVirtualHosted)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
+		})
+
+		Convey("Global virtual hosted style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", expectedBucketName, expectedKey)
+			urlStr, err := s3Url.String(s3client.StyleGlobalVirtualHosted)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
+		})
+
+		Convey("DNS Alias virtual hosted style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://%s/%s", expectedBucketName, expectedKey)
+			urlStr, err := s3Url.String(s3client.StyleAliasVirtualHosted)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
+		})
+	})
+}
+
+func TestNoRegionUrl(t *testing.T) {
+
+	const expectedBucketName = "csv-bucket"
+	const expectedKey = "dir1/test-file.csv"
+
+	Convey("Given an instance of S3Url with valid bucketName, region and object key", t, func() {
+		s3Url, err := s3client.NewURL("", expectedBucketName, expectedKey)
+		So(err, ShouldBeNil)
+
+		Convey("Getters return the expected values", func() {
+			So(s3Url.Region(), ShouldEqual, "")
+			So(s3Url.BucketName(), ShouldEqual, expectedBucketName)
+			So(s3Url.Key(), ShouldEqual, expectedKey)
+		})
+
+		Convey("Path style URL string is formatted as expected", func() {
+			_, err := s3Url.String(s3client.StylePath)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Global Path style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://s3.amazonaws.com/%s/%s", expectedBucketName, expectedKey)
+			urlStr, err := s3Url.String(s3client.StyleGlobalPath)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
+		})
+
+		Convey("Virtual hosted style URL string is formatted as expected", func() {
+			_, err := s3Url.String(s3client.StyleVirtualHosted)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Global virtual hosted style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", expectedBucketName, expectedKey)
+			urlStr, err := s3Url.String(s3client.StyleGlobalVirtualHosted)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
+		})
+
+		Convey("DNS Alias virtual hosted style URL string is formatted as expected", func() {
+			expectedStr := fmt.Sprintf("https://%s/%s", expectedBucketName, expectedKey)
+			urlStr, err := s3Url.String(s3client.StyleAliasVirtualHosted)
+			So(err, ShouldBeNil)
+			So(urlStr, ShouldEqual, expectedStr)
+		})
+	})
+}
+
+func TestParsing(t *testing.T) {
+
+	const expectedBucketName = "csv-bucket"
+	const expectedKey = "dir1/test-file.csv"
+	const expectedRegion = "eu-west-1"
+
+	styles := []s3client.URLStyle{
+		s3client.StylePath,
+		s3client.StyleGlobalPath,
+		s3client.StyleVirtualHosted,
+		s3client.StyleGlobalVirtualHosted,
+		s3client.StyleAliasVirtualHosted,
+	}
+
+	Convey("Given S3 raw url strings in different acceptable formats", t, func() {
+		// urls that define region
+		regionalUrls := map[s3client.URLStyle][]string{
+			s3client.StylePath: []string{
+				"https://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv",
+				"s3://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv"},
+			s3client.StyleVirtualHosted: []string{
+				"https://csv-bucket.s3-eu-west-1.amazonaws.com/dir1/test-file.csv",
+				"s3://csv-bucket.s3-eu-west-1.amazonaws.com/dir1/test-file.csv"},
+		}
+		expectedRegionalS3Url, err := s3client.NewURL(expectedRegion, expectedBucketName, expectedKey)
+		So(err, ShouldBeNil)
+
+		// urls that don't define region
+		globalUrls := map[s3client.URLStyle][]string{
+			s3client.StyleGlobalPath: []string{
+				"https://s3.amazonaws.com/csv-bucket/dir1/test-file.csv",
+				"s3://s3.amazonaws.com/csv-bucket/dir1/test-file.csv"},
+			s3client.StyleGlobalVirtualHosted: []string{
+				"https://csv-bucket.s3.amazonaws.com/dir1/test-file.csv",
+				"s3://csv-bucket.s3.amazonaws.com/dir1/test-file.csv"},
+			s3client.StyleAliasVirtualHosted: []string{
+				"https://csv-bucket/dir1/test-file.csv",
+				"s3://csv-bucket/dir1/test-file.csv"},
+		}
+		expectedGlobalS3Url, err := s3client.NewURL("", expectedBucketName, expectedKey)
+		So(err, ShouldBeNil)
+
+		Convey("Each format is correctly parsed, successfully retreiving bucket, key and region (if available)", func() {
+			for style, urls := range regionalUrls {
+				for _, url := range urls {
+					s3Url, err := s3client.ParseURL(url, style)
+					So(err, ShouldBeNil)
+					So(s3Url, ShouldResemble, expectedRegionalS3Url)
+				}
+			}
+			for style, urls := range globalUrls {
+				for _, url := range urls {
+					s3Url, err := s3client.ParseURL(url, style)
+					So(err, ShouldBeNil)
+					So(s3Url, ShouldResemble, expectedGlobalS3Url)
+				}
+			}
+		})
+
+		Convey("A path-style url can be parsed as a global-path-style with empty region", func() {
+			for _, url := range regionalUrls[s3client.StylePath] {
+				s3Url, err := s3client.ParseURL(url, s3client.StyleGlobalPath)
+				So(err, ShouldBeNil)
+				So(s3Url, ShouldResemble, expectedGlobalS3Url)
+			}
+		})
+
+		Convey("A global-path-style url can be parsed as a path-style with empty region", func() {
+			for _, url := range regionalUrls[s3client.StyleGlobalPath] {
+				s3Url, err := s3client.ParseURL(url, s3client.StylePath)
+				So(err, ShouldBeNil)
+				So(s3Url, ShouldResemble, expectedGlobalS3Url)
+			}
+		})
+	})
+
+	Convey("Trying to parse an empty S3 raw url results in error ", t, func() {
+		for _, style := range styles {
+			_, err := s3client.ParseURL("", style)
+			So(err, ShouldNotBeNil)
+		}
+	})
+
+	Convey("Tying to parse an s3 url that is missing the object key, results in error", t, func() {
+		missingBucketUrl := "s3://some-file"
+		for _, style := range styles {
+			_, err := s3client.ParseURL(missingBucketUrl, style)
+			So(err, ShouldNotBeNil)
+		}
+	})
+
+	Convey("Trying to parse an s3 url with empty bucket or key results in error", t, func() {
+		emptyValuesUrl1 := "s3://///////"
+		emptyValuesUrl2 := fmt.Sprintf("s3:/%s/", expectedBucketName)
+		for _, style := range styles {
+			_, err := s3client.ParseURL(emptyValuesUrl1, style)
+			So(err, ShouldNotBeNil)
+			_, err = s3client.ParseURL(emptyValuesUrl2, style)
+			So(err, ShouldNotBeNil)
+		}
+	})
+
+	Convey("Tying to parse an s3 url that is missing the bucket name and object key results in error", t, func() {
+		missingBucketUrl := "s3://"
+		for _, style := range styles {
+			_, err := s3client.ParseURL(missingBucketUrl, style)
+			So(err, ShouldNotBeNil)
+		}
+	})
+
+	Convey("Trying to parse a malformed s3 url results in error", t, func() {
+		malformedURL := "This%Url%Is%Malformed"
+		for _, style := range styles {
+			_, err := s3client.ParseURL(malformedURL, style)
+			So(err, ShouldNotBeNil)
+		}
+	})
+}
+
+func TestNewURL(t *testing.T) {
+
+	const expectedBucketName = "csv-bucket"
+	const expectedKey = "dir1/test-file.csv"
+	const expectedRegion = "eu-west-1"
+
+	Convey("Given valid region, bucket name and key results in New creating the expected S3Url struct", t, func() {
+		s3Url, err := s3client.NewURL(expectedRegion, expectedBucketName, expectedKey)
+		So(err, ShouldBeNil)
+		So(s3Url.Region(), ShouldEqual, expectedRegion)
+		So(s3Url.BucketName(), ShouldEqual, expectedBucketName)
+		So(s3Url.Key(), ShouldEqual, expectedKey)
+	})
+
+	Convey("Given an empty region, valid bucket name and key results in New creating the expected S3Url struct", t, func() {
+		s3Url, err := s3client.NewURL("", expectedBucketName, expectedKey)
+		So(err, ShouldBeNil)
+		So(s3Url.Region(), ShouldEqual, "")
+		So(s3Url.BucketName(), ShouldEqual, expectedBucketName)
+		So(s3Url.Key(), ShouldEqual, expectedKey)
+	})
+
+	Convey("Given an empty bucket results in error trying to create a new S3Url", t, func() {
+		_, err := s3client.NewURL(expectedRegion, "", expectedKey)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Given an empty key results in error trying to create a new S3Url", t, func() {
+		_, err := s3client.NewURL(expectedRegion, expectedBucketName, "")
+		So(err, ShouldNotBeNil)
 	})
 }

--- a/url_test.go
+++ b/url_test.go
@@ -26,35 +26,35 @@ func TestFullyDefinedUrl(t *testing.T) {
 
 		Convey("Path style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", expectedRegion, expectedBucketName, expectedKey)
-			urlStr, err := s3Url.String(s3client.StylePath)
+			urlStr, err := s3Url.String(s3client.PathStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
 
 		Convey("Global Path style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://s3.amazonaws.com/%s/%s", expectedBucketName, expectedKey)
-			urlStr, err := s3Url.String(s3client.StyleGlobalPath)
+			urlStr, err := s3Url.String(s3client.GlobalPathStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
 
 		Convey("Virtual hosted style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://%s.s3-%s.amazonaws.com/%s", expectedBucketName, expectedRegion, expectedKey)
-			urlStr, err := s3Url.String(s3client.StyleVirtualHosted)
+			urlStr, err := s3Url.String(s3client.VirtualHostedStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
 
 		Convey("Global virtual hosted style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", expectedBucketName, expectedKey)
-			urlStr, err := s3Url.String(s3client.StyleGlobalVirtualHosted)
+			urlStr, err := s3Url.String(s3client.GlobalVirtualHostedStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
 
 		Convey("DNS Alias virtual hosted style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://%s/%s", expectedBucketName, expectedKey)
-			urlStr, err := s3Url.String(s3client.StyleAliasVirtualHosted)
+			urlStr, err := s3Url.String(s3client.AliasVirtualHostedStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
@@ -77,32 +77,32 @@ func TestNoRegionUrl(t *testing.T) {
 		})
 
 		Convey("Path style URL string is formatted as expected", func() {
-			_, err := s3Url.String(s3client.StylePath)
+			_, err := s3Url.String(s3client.PathStyle)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Global Path style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://s3.amazonaws.com/%s/%s", expectedBucketName, expectedKey)
-			urlStr, err := s3Url.String(s3client.StyleGlobalPath)
+			urlStr, err := s3Url.String(s3client.GlobalPathStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
 
 		Convey("Virtual hosted style URL string is formatted as expected", func() {
-			_, err := s3Url.String(s3client.StyleVirtualHosted)
+			_, err := s3Url.String(s3client.VirtualHostedStyle)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Global virtual hosted style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", expectedBucketName, expectedKey)
-			urlStr, err := s3Url.String(s3client.StyleGlobalVirtualHosted)
+			urlStr, err := s3Url.String(s3client.GlobalVirtualHostedStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
 
 		Convey("DNS Alias virtual hosted style URL string is formatted as expected", func() {
 			expectedStr := fmt.Sprintf("https://%s/%s", expectedBucketName, expectedKey)
-			urlStr, err := s3Url.String(s3client.StyleAliasVirtualHosted)
+			urlStr, err := s3Url.String(s3client.AliasVirtualHostedStyle)
 			So(err, ShouldBeNil)
 			So(urlStr, ShouldEqual, expectedStr)
 		})
@@ -128,23 +128,23 @@ func TestParsing(t *testing.T) {
 
 		// URLs by style and expected generated s3Url objects
 		urls := map[s3client.URLStyle]map[string]*s3client.S3Url{
-			s3client.StylePath: map[string]*s3client.S3Url{
+			s3client.PathStyle: map[string]*s3client.S3Url{
 				"https://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv": expectedRegionalHttpsUrl,
 				"s3://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv":    expectedRegionalS3Url,
 			},
-			s3client.StyleVirtualHosted: map[string]*s3client.S3Url{
+			s3client.VirtualHostedStyle: map[string]*s3client.S3Url{
 				"https://csv-bucket.s3-eu-west-1.amazonaws.com/dir1/test-file.csv": expectedRegionalHttpsUrl,
 				"s3://csv-bucket.s3-eu-west-1.amazonaws.com/dir1/test-file.csv":    expectedRegionalS3Url,
 			},
-			s3client.StyleGlobalPath: map[string]*s3client.S3Url{
+			s3client.GlobalPathStyle: map[string]*s3client.S3Url{
 				"https://s3.amazonaws.com/csv-bucket/dir1/test-file.csv": expectedGlobalHttpsUrl,
 				"s3://s3.amazonaws.com/csv-bucket/dir1/test-file.csv":    expectedGlobalS3Url,
 			},
-			s3client.StyleGlobalVirtualHosted: map[string]*s3client.S3Url{
+			s3client.GlobalVirtualHostedStyle: map[string]*s3client.S3Url{
 				"https://csv-bucket.s3.amazonaws.com/dir1/test-file.csv": expectedGlobalHttpsUrl,
 				"s3://csv-bucket.s3.amazonaws.com/dir1/test-file.csv":    expectedGlobalS3Url,
 			},
-			s3client.StyleAliasVirtualHosted: map[string]*s3client.S3Url{
+			s3client.AliasVirtualHostedStyle: map[string]*s3client.S3Url{
 				"https://csv-bucket/dir1/test-file.csv": expectedGlobalHttpsUrl,
 				"s3://csv-bucket/dir1/test-file.csv":    expectedGlobalS3Url,
 			},
@@ -162,11 +162,11 @@ func TestParsing(t *testing.T) {
 
 		Convey("A path-style url can be parsed as a global-path-style with empty region", func() {
 			s3Url, err := s3client.ParseURL(
-				"https://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv", s3client.StyleGlobalPath)
+				"https://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv", s3client.GlobalPathStyle)
 			So(err, ShouldBeNil)
 			So(s3Url, ShouldResemble, expectedGlobalHttpsUrl)
 			s3Url, err = s3client.ParseURL(
-				"s3://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv", s3client.StyleGlobalPath)
+				"s3://s3-eu-west-1.amazonaws.com/csv-bucket/dir1/test-file.csv", s3client.GlobalPathStyle)
 			So(err, ShouldBeNil)
 			So(s3Url, ShouldResemble, expectedGlobalS3Url)
 		})


### PR DESCRIPTION
### What

As part of the code migration from dp-dimension-extractor, Improved URL string manipulation for S3, to support more [style formats](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html)
- Support path and virtual hosted styles (with and without region), as well as DNS-alias style (scheme://bucket/k/e/y)
  - String() returned in all different format styles, according to flag
  - Parse() accepts all different format styles, according to flag
  - Extra parse methods for each format style
- Documented usage in README.md

### How to review

- Check that code changes make sense.
- Unit tests should pass.

### Who can review

Anyone.