### PR TITLE
remove redundant .travis.yml as travis no longer in use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: go
-go:
- - 1.12
- - tip
- script:
-    - export GO111MODULE="on"
-    - make test
-    


### PR DESCRIPTION
### What

removed .travis.yml as we don't use travis anywmore and SOC don't like the config being there

### How to review

check I have removed .travis.yml

### Who can review

anyone
