### PR TITLE
Implemented s3 client Head, by wrapping AWS SDK's HeadObject call

### DIFF
--- a/client.go
+++ b/client.go
@@ -390,10 +390,27 @@ func (cli *S3) GetWithPSK(key string, psk []byte) (io.ReadCloser, *int64, error)
 	return result.Body, result.ContentLength, nil
 }
 
+// Head returns a HeadObjectOutput containing an object metadata obtained from ah HTTP HEAD call
+func (cli *S3) Head(key string) (*s3.HeadObjectOutput, error) {
+	result, err := cli.sdkClient.HeadObject(&s3.HeadObjectInput{
+		Bucket: &cli.bucketName,
+		Key:    &key,
+	})
+	if err != nil {
+		return nil, NewError(
+			fmt.Errorf("error trying to obtain s3 object metadata with HeadObject call: %w", err),
+			log.Data{
+				"bucket_name": cli.bucketName,
+				"s3_key":      key, // key is the s3 filename with path (it's not a cryptographic key)
+			},
+		)
+	}
+	return result, nil
+}
+
 // PutWithPSK uploads the provided contents to the key in the bucket configured for this client, using the provided PSK.
 // The 'key' parameter refers to the path for the file under the bucket.
 func (cli *S3) PutWithPSK(key *string, reader *bytes.Reader, psk []byte) error {
-
 	input := &s3.PutObjectInput{
 		Body:   reader,
 		Key:    key,

--- a/ifaces.go
+++ b/ifaces.go
@@ -14,29 +14,30 @@ import (
 
 // S3SDKClient represents the sdk client with methods required by dp-s3 client
 type S3SDKClient interface {
-	ListMultipartUploads(*s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error)
-	ListParts(*s3.ListPartsInput) (*s3.ListPartsOutput, error)
-	CompleteMultipartUpload(*s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
-	CreateMultipartUpload(*s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
-	UploadPart(*s3.UploadPartInput) (*s3.UploadPartOutput, error)
-	HeadBucket(*s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
-	GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error)
+	ListMultipartUploads(in *s3.ListMultipartUploadsInput) (out *s3.ListMultipartUploadsOutput, err error)
+	ListParts(in *s3.ListPartsInput) (out *s3.ListPartsOutput, err error)
+	CompleteMultipartUpload(in *s3.CompleteMultipartUploadInput) (out *s3.CompleteMultipartUploadOutput, err error)
+	CreateMultipartUpload(in *s3.CreateMultipartUploadInput) (out *s3.CreateMultipartUploadOutput, err error)
+	UploadPart(in *s3.UploadPartInput) (out *s3.UploadPartOutput, err error)
+	HeadBucket(in *s3.HeadBucketInput) (out *s3.HeadBucketOutput, err error)
+	HeadObject(in *s3.HeadObjectInput) (out *s3.HeadObjectOutput, err error)
+	GetObject(in *s3.GetObjectInput) (out *s3.GetObjectOutput, err error)
 }
 
 // S3CryptoClient represents the cryptoclient with methods required to upload parts with encryption
 type S3CryptoClient interface {
-	UploadPartWithPSK(*s3.UploadPartInput, []byte) (*s3.UploadPartOutput, error)
-	GetObjectWithPSK(*s3.GetObjectInput, []byte) (*s3.GetObjectOutput, error)
-	PutObjectWithPSK(*s3.PutObjectInput, []byte) (*s3.PutObjectOutput, error)
+	UploadPartWithPSK(in *s3.UploadPartInput, psk []byte) (out *s3.UploadPartOutput, err error)
+	GetObjectWithPSK(in *s3.GetObjectInput, psk []byte) (out *s3.GetObjectOutput, err error)
+	PutObjectWithPSK(in *s3.PutObjectInput, psk []byte) (out *s3.PutObjectOutput, err error)
 }
 
 // S3SDKUploader represents the sdk uploader with methods required by dp-s3 client
 type S3SDKUploader interface {
-	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
-	UploadWithContext(context.Context, *s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+	Upload(in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (out *s3manager.UploadOutput, err error)
+	UploadWithContext(ctx context.Context, in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (out *s3manager.UploadOutput, err error)
 }
 
 // S3CryptoUploader represents the s3crypto Uploader with methods required to upload parts with encryption
 type S3CryptoUploader interface {
-	UploadWithPSK(*s3manager.UploadInput, []byte) (*s3manager.UploadOutput, error)
+	UploadWithPSK(in *s3manager.UploadInput, psk []byte) (out *s3manager.UploadOutput, err error)
 }

--- a/mock/s3-crypto-uploader.go
+++ b/mock/s3-crypto-uploader.go
@@ -9,73 +9,76 @@ import (
 	"sync"
 )
 
+var (
+	lockS3CryptoUploaderMockUploadWithPSK sync.RWMutex
+)
+
 // Ensure, that S3CryptoUploaderMock does implement s3client.S3CryptoUploader.
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3CryptoUploader = &S3CryptoUploaderMock{}
 
 // S3CryptoUploaderMock is a mock implementation of s3client.S3CryptoUploader.
 //
-// 	func TestSomethingThatUsesS3CryptoUploader(t *testing.T) {
+//     func TestSomethingThatUsesS3CryptoUploader(t *testing.T) {
 //
-// 		// make and configure a mocked s3client.S3CryptoUploader
-// 		mockedS3CryptoUploader := &S3CryptoUploaderMock{
-// 			UploadWithPSKFunc: func(uploadInput *s3manager.UploadInput, bytes []byte) (*s3manager.UploadOutput, error) {
-// 				panic("mock out the UploadWithPSK method")
-// 			},
-// 		}
+//         // make and configure a mocked s3client.S3CryptoUploader
+//         mockedS3CryptoUploader := &S3CryptoUploaderMock{
+//             UploadWithPSKFunc: func(in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
+// 	               panic("mock out the UploadWithPSK method")
+//             },
+//         }
 //
-// 		// use mockedS3CryptoUploader in code that requires s3client.S3CryptoUploader
-// 		// and then make assertions.
+//         // use mockedS3CryptoUploader in code that requires s3client.S3CryptoUploader
+//         // and then make assertions.
 //
-// 	}
+//     }
 type S3CryptoUploaderMock struct {
 	// UploadWithPSKFunc mocks the UploadWithPSK method.
-	UploadWithPSKFunc func(uploadInput *s3manager.UploadInput, bytes []byte) (*s3manager.UploadOutput, error)
+	UploadWithPSKFunc func(in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// UploadWithPSK holds details about calls to the UploadWithPSK method.
 		UploadWithPSK []struct {
-			// UploadInput is the uploadInput argument value.
-			UploadInput *s3manager.UploadInput
-			// Bytes is the bytes argument value.
-			Bytes []byte
+			// In is the in argument value.
+			In *s3manager.UploadInput
+			// Psk is the psk argument value.
+			Psk []byte
 		}
 	}
-	lockUploadWithPSK sync.RWMutex
 }
 
 // UploadWithPSK calls UploadWithPSKFunc.
-func (mock *S3CryptoUploaderMock) UploadWithPSK(uploadInput *s3manager.UploadInput, bytes []byte) (*s3manager.UploadOutput, error) {
+func (mock *S3CryptoUploaderMock) UploadWithPSK(in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
 	if mock.UploadWithPSKFunc == nil {
 		panic("S3CryptoUploaderMock.UploadWithPSKFunc: method is nil but S3CryptoUploader.UploadWithPSK was just called")
 	}
 	callInfo := struct {
-		UploadInput *s3manager.UploadInput
-		Bytes       []byte
+		In  *s3manager.UploadInput
+		Psk []byte
 	}{
-		UploadInput: uploadInput,
-		Bytes:       bytes,
+		In:  in,
+		Psk: psk,
 	}
-	mock.lockUploadWithPSK.Lock()
+	lockS3CryptoUploaderMockUploadWithPSK.Lock()
 	mock.calls.UploadWithPSK = append(mock.calls.UploadWithPSK, callInfo)
-	mock.lockUploadWithPSK.Unlock()
-	return mock.UploadWithPSKFunc(uploadInput, bytes)
+	lockS3CryptoUploaderMockUploadWithPSK.Unlock()
+	return mock.UploadWithPSKFunc(in, psk)
 }
 
 // UploadWithPSKCalls gets all the calls that were made to UploadWithPSK.
 // Check the length with:
 //     len(mockedS3CryptoUploader.UploadWithPSKCalls())
 func (mock *S3CryptoUploaderMock) UploadWithPSKCalls() []struct {
-	UploadInput *s3manager.UploadInput
-	Bytes       []byte
+	In  *s3manager.UploadInput
+	Psk []byte
 } {
 	var calls []struct {
-		UploadInput *s3manager.UploadInput
-		Bytes       []byte
+		In  *s3manager.UploadInput
+		Psk []byte
 	}
-	mock.lockUploadWithPSK.RLock()
+	lockS3CryptoUploaderMockUploadWithPSK.RLock()
 	calls = mock.calls.UploadWithPSK
-	mock.lockUploadWithPSK.RUnlock()
+	lockS3CryptoUploaderMockUploadWithPSK.RUnlock()
 	return calls
 }

--- a/mock/s3-crypto-uploader.go
+++ b/mock/s3-crypto-uploader.go
@@ -17,6 +17,7 @@ var (
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3CryptoUploader = &S3CryptoUploaderMock{}
 
+// Example of how to instantiate a mock for testing - this code is automatically generated
 // S3CryptoUploaderMock is a mock implementation of s3client.S3CryptoUploader.
 //
 //     func TestSomethingThatUsesS3CryptoUploader(t *testing.T) {

--- a/mock/s3-crypto.go
+++ b/mock/s3-crypto.go
@@ -9,171 +9,174 @@ import (
 	"sync"
 )
 
+var (
+	lockS3CryptoClientMockGetObjectWithPSK  sync.RWMutex
+	lockS3CryptoClientMockPutObjectWithPSK  sync.RWMutex
+	lockS3CryptoClientMockUploadPartWithPSK sync.RWMutex
+)
+
 // Ensure, that S3CryptoClientMock does implement s3client.S3CryptoClient.
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3CryptoClient = &S3CryptoClientMock{}
 
 // S3CryptoClientMock is a mock implementation of s3client.S3CryptoClient.
 //
-// 	func TestSomethingThatUsesS3CryptoClient(t *testing.T) {
+//     func TestSomethingThatUsesS3CryptoClient(t *testing.T) {
 //
-// 		// make and configure a mocked s3client.S3CryptoClient
-// 		mockedS3CryptoClient := &S3CryptoClientMock{
-// 			GetObjectWithPSKFunc: func(getObjectInput *s3.GetObjectInput, bytes []byte) (*s3.GetObjectOutput, error) {
-// 				panic("mock out the GetObjectWithPSK method")
-// 			},
-// 			PutObjectWithPSKFunc: func(putObjectInput *s3.PutObjectInput, bytes []byte) (*s3.PutObjectOutput, error) {
-// 				panic("mock out the PutObjectWithPSK method")
-// 			},
-// 			UploadPartWithPSKFunc: func(uploadPartInput *s3.UploadPartInput, bytes []byte) (*s3.UploadPartOutput, error) {
-// 				panic("mock out the UploadPartWithPSK method")
-// 			},
-// 		}
+//         // make and configure a mocked s3client.S3CryptoClient
+//         mockedS3CryptoClient := &S3CryptoClientMock{
+//             GetObjectWithPSKFunc: func(in *s3.GetObjectInput, psk []byte) (*s3.GetObjectOutput, error) {
+// 	               panic("mock out the GetObjectWithPSK method")
+//             },
+//             PutObjectWithPSKFunc: func(in *s3.PutObjectInput, psk []byte) (*s3.PutObjectOutput, error) {
+// 	               panic("mock out the PutObjectWithPSK method")
+//             },
+//             UploadPartWithPSKFunc: func(in *s3.UploadPartInput, psk []byte) (*s3.UploadPartOutput, error) {
+// 	               panic("mock out the UploadPartWithPSK method")
+//             },
+//         }
 //
-// 		// use mockedS3CryptoClient in code that requires s3client.S3CryptoClient
-// 		// and then make assertions.
+//         // use mockedS3CryptoClient in code that requires s3client.S3CryptoClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type S3CryptoClientMock struct {
 	// GetObjectWithPSKFunc mocks the GetObjectWithPSK method.
-	GetObjectWithPSKFunc func(getObjectInput *s3.GetObjectInput, bytes []byte) (*s3.GetObjectOutput, error)
+	GetObjectWithPSKFunc func(in *s3.GetObjectInput, psk []byte) (*s3.GetObjectOutput, error)
 
 	// PutObjectWithPSKFunc mocks the PutObjectWithPSK method.
-	PutObjectWithPSKFunc func(putObjectInput *s3.PutObjectInput, bytes []byte) (*s3.PutObjectOutput, error)
+	PutObjectWithPSKFunc func(in *s3.PutObjectInput, psk []byte) (*s3.PutObjectOutput, error)
 
 	// UploadPartWithPSKFunc mocks the UploadPartWithPSK method.
-	UploadPartWithPSKFunc func(uploadPartInput *s3.UploadPartInput, bytes []byte) (*s3.UploadPartOutput, error)
+	UploadPartWithPSKFunc func(in *s3.UploadPartInput, psk []byte) (*s3.UploadPartOutput, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// GetObjectWithPSK holds details about calls to the GetObjectWithPSK method.
 		GetObjectWithPSK []struct {
-			// GetObjectInput is the getObjectInput argument value.
-			GetObjectInput *s3.GetObjectInput
-			// Bytes is the bytes argument value.
-			Bytes []byte
+			// In is the in argument value.
+			In *s3.GetObjectInput
+			// Psk is the psk argument value.
+			Psk []byte
 		}
 		// PutObjectWithPSK holds details about calls to the PutObjectWithPSK method.
 		PutObjectWithPSK []struct {
-			// PutObjectInput is the putObjectInput argument value.
-			PutObjectInput *s3.PutObjectInput
-			// Bytes is the bytes argument value.
-			Bytes []byte
+			// In is the in argument value.
+			In *s3.PutObjectInput
+			// Psk is the psk argument value.
+			Psk []byte
 		}
 		// UploadPartWithPSK holds details about calls to the UploadPartWithPSK method.
 		UploadPartWithPSK []struct {
-			// UploadPartInput is the uploadPartInput argument value.
-			UploadPartInput *s3.UploadPartInput
-			// Bytes is the bytes argument value.
-			Bytes []byte
+			// In is the in argument value.
+			In *s3.UploadPartInput
+			// Psk is the psk argument value.
+			Psk []byte
 		}
 	}
-	lockGetObjectWithPSK  sync.RWMutex
-	lockPutObjectWithPSK  sync.RWMutex
-	lockUploadPartWithPSK sync.RWMutex
 }
 
 // GetObjectWithPSK calls GetObjectWithPSKFunc.
-func (mock *S3CryptoClientMock) GetObjectWithPSK(getObjectInput *s3.GetObjectInput, bytes []byte) (*s3.GetObjectOutput, error) {
+func (mock *S3CryptoClientMock) GetObjectWithPSK(in *s3.GetObjectInput, psk []byte) (*s3.GetObjectOutput, error) {
 	if mock.GetObjectWithPSKFunc == nil {
 		panic("S3CryptoClientMock.GetObjectWithPSKFunc: method is nil but S3CryptoClient.GetObjectWithPSK was just called")
 	}
 	callInfo := struct {
-		GetObjectInput *s3.GetObjectInput
-		Bytes          []byte
+		In  *s3.GetObjectInput
+		Psk []byte
 	}{
-		GetObjectInput: getObjectInput,
-		Bytes:          bytes,
+		In:  in,
+		Psk: psk,
 	}
-	mock.lockGetObjectWithPSK.Lock()
+	lockS3CryptoClientMockGetObjectWithPSK.Lock()
 	mock.calls.GetObjectWithPSK = append(mock.calls.GetObjectWithPSK, callInfo)
-	mock.lockGetObjectWithPSK.Unlock()
-	return mock.GetObjectWithPSKFunc(getObjectInput, bytes)
+	lockS3CryptoClientMockGetObjectWithPSK.Unlock()
+	return mock.GetObjectWithPSKFunc(in, psk)
 }
 
 // GetObjectWithPSKCalls gets all the calls that were made to GetObjectWithPSK.
 // Check the length with:
 //     len(mockedS3CryptoClient.GetObjectWithPSKCalls())
 func (mock *S3CryptoClientMock) GetObjectWithPSKCalls() []struct {
-	GetObjectInput *s3.GetObjectInput
-	Bytes          []byte
+	In  *s3.GetObjectInput
+	Psk []byte
 } {
 	var calls []struct {
-		GetObjectInput *s3.GetObjectInput
-		Bytes          []byte
+		In  *s3.GetObjectInput
+		Psk []byte
 	}
-	mock.lockGetObjectWithPSK.RLock()
+	lockS3CryptoClientMockGetObjectWithPSK.RLock()
 	calls = mock.calls.GetObjectWithPSK
-	mock.lockGetObjectWithPSK.RUnlock()
+	lockS3CryptoClientMockGetObjectWithPSK.RUnlock()
 	return calls
 }
 
 // PutObjectWithPSK calls PutObjectWithPSKFunc.
-func (mock *S3CryptoClientMock) PutObjectWithPSK(putObjectInput *s3.PutObjectInput, bytes []byte) (*s3.PutObjectOutput, error) {
+func (mock *S3CryptoClientMock) PutObjectWithPSK(in *s3.PutObjectInput, psk []byte) (*s3.PutObjectOutput, error) {
 	if mock.PutObjectWithPSKFunc == nil {
 		panic("S3CryptoClientMock.PutObjectWithPSKFunc: method is nil but S3CryptoClient.PutObjectWithPSK was just called")
 	}
 	callInfo := struct {
-		PutObjectInput *s3.PutObjectInput
-		Bytes          []byte
+		In  *s3.PutObjectInput
+		Psk []byte
 	}{
-		PutObjectInput: putObjectInput,
-		Bytes:          bytes,
+		In:  in,
+		Psk: psk,
 	}
-	mock.lockPutObjectWithPSK.Lock()
+	lockS3CryptoClientMockPutObjectWithPSK.Lock()
 	mock.calls.PutObjectWithPSK = append(mock.calls.PutObjectWithPSK, callInfo)
-	mock.lockPutObjectWithPSK.Unlock()
-	return mock.PutObjectWithPSKFunc(putObjectInput, bytes)
+	lockS3CryptoClientMockPutObjectWithPSK.Unlock()
+	return mock.PutObjectWithPSKFunc(in, psk)
 }
 
 // PutObjectWithPSKCalls gets all the calls that were made to PutObjectWithPSK.
 // Check the length with:
 //     len(mockedS3CryptoClient.PutObjectWithPSKCalls())
 func (mock *S3CryptoClientMock) PutObjectWithPSKCalls() []struct {
-	PutObjectInput *s3.PutObjectInput
-	Bytes          []byte
+	In  *s3.PutObjectInput
+	Psk []byte
 } {
 	var calls []struct {
-		PutObjectInput *s3.PutObjectInput
-		Bytes          []byte
+		In  *s3.PutObjectInput
+		Psk []byte
 	}
-	mock.lockPutObjectWithPSK.RLock()
+	lockS3CryptoClientMockPutObjectWithPSK.RLock()
 	calls = mock.calls.PutObjectWithPSK
-	mock.lockPutObjectWithPSK.RUnlock()
+	lockS3CryptoClientMockPutObjectWithPSK.RUnlock()
 	return calls
 }
 
 // UploadPartWithPSK calls UploadPartWithPSKFunc.
-func (mock *S3CryptoClientMock) UploadPartWithPSK(uploadPartInput *s3.UploadPartInput, bytes []byte) (*s3.UploadPartOutput, error) {
+func (mock *S3CryptoClientMock) UploadPartWithPSK(in *s3.UploadPartInput, psk []byte) (*s3.UploadPartOutput, error) {
 	if mock.UploadPartWithPSKFunc == nil {
 		panic("S3CryptoClientMock.UploadPartWithPSKFunc: method is nil but S3CryptoClient.UploadPartWithPSK was just called")
 	}
 	callInfo := struct {
-		UploadPartInput *s3.UploadPartInput
-		Bytes           []byte
+		In  *s3.UploadPartInput
+		Psk []byte
 	}{
-		UploadPartInput: uploadPartInput,
-		Bytes:           bytes,
+		In:  in,
+		Psk: psk,
 	}
-	mock.lockUploadPartWithPSK.Lock()
+	lockS3CryptoClientMockUploadPartWithPSK.Lock()
 	mock.calls.UploadPartWithPSK = append(mock.calls.UploadPartWithPSK, callInfo)
-	mock.lockUploadPartWithPSK.Unlock()
-	return mock.UploadPartWithPSKFunc(uploadPartInput, bytes)
+	lockS3CryptoClientMockUploadPartWithPSK.Unlock()
+	return mock.UploadPartWithPSKFunc(in, psk)
 }
 
 // UploadPartWithPSKCalls gets all the calls that were made to UploadPartWithPSK.
 // Check the length with:
 //     len(mockedS3CryptoClient.UploadPartWithPSKCalls())
 func (mock *S3CryptoClientMock) UploadPartWithPSKCalls() []struct {
-	UploadPartInput *s3.UploadPartInput
-	Bytes           []byte
+	In  *s3.UploadPartInput
+	Psk []byte
 } {
 	var calls []struct {
-		UploadPartInput *s3.UploadPartInput
-		Bytes           []byte
+		In  *s3.UploadPartInput
+		Psk []byte
 	}
-	mock.lockUploadPartWithPSK.RLock()
+	lockS3CryptoClientMockUploadPartWithPSK.RLock()
 	calls = mock.calls.UploadPartWithPSK
-	mock.lockUploadPartWithPSK.RUnlock()
+	lockS3CryptoClientMockUploadPartWithPSK.RUnlock()
 	return calls
 }

--- a/mock/s3-crypto.go
+++ b/mock/s3-crypto.go
@@ -19,6 +19,7 @@ var (
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3CryptoClient = &S3CryptoClientMock{}
 
+// Example of how to instantiate a mock for testing - this code is automatically generated
 // S3CryptoClientMock is a mock implementation of s3client.S3CryptoClient.
 //
 //     func TestSomethingThatUsesS3CryptoClient(t *testing.T) {

--- a/mock/s3-sdk.go
+++ b/mock/s3-sdk.go
@@ -9,325 +9,371 @@ import (
 	"sync"
 )
 
+var (
+	lockS3SDKClientMockCompleteMultipartUpload sync.RWMutex
+	lockS3SDKClientMockCreateMultipartUpload   sync.RWMutex
+	lockS3SDKClientMockGetObject               sync.RWMutex
+	lockS3SDKClientMockHeadBucket              sync.RWMutex
+	lockS3SDKClientMockHeadObject              sync.RWMutex
+	lockS3SDKClientMockListMultipartUploads    sync.RWMutex
+	lockS3SDKClientMockListParts               sync.RWMutex
+	lockS3SDKClientMockUploadPart              sync.RWMutex
+)
+
 // Ensure, that S3SDKClientMock does implement s3client.S3SDKClient.
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3SDKClient = &S3SDKClientMock{}
 
 // S3SDKClientMock is a mock implementation of s3client.S3SDKClient.
 //
-// 	func TestSomethingThatUsesS3SDKClient(t *testing.T) {
+//     func TestSomethingThatUsesS3SDKClient(t *testing.T) {
 //
-// 		// make and configure a mocked s3client.S3SDKClient
-// 		mockedS3SDKClient := &S3SDKClientMock{
-// 			CompleteMultipartUploadFunc: func(completeMultipartUploadInput *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
-// 				panic("mock out the CompleteMultipartUpload method")
-// 			},
-// 			CreateMultipartUploadFunc: func(createMultipartUploadInput *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error) {
-// 				panic("mock out the CreateMultipartUpload method")
-// 			},
-// 			GetObjectFunc: func(getObjectInput *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-// 				panic("mock out the GetObject method")
-// 			},
-// 			HeadBucketFunc: func(headBucketInput *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
-// 				panic("mock out the HeadBucket method")
-// 			},
-// 			ListMultipartUploadsFunc: func(listMultipartUploadsInput *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error) {
-// 				panic("mock out the ListMultipartUploads method")
-// 			},
-// 			ListPartsFunc: func(listPartsInput *s3.ListPartsInput) (*s3.ListPartsOutput, error) {
-// 				panic("mock out the ListParts method")
-// 			},
-// 			UploadPartFunc: func(uploadPartInput *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
-// 				panic("mock out the UploadPart method")
-// 			},
-// 		}
+//         // make and configure a mocked s3client.S3SDKClient
+//         mockedS3SDKClient := &S3SDKClientMock{
+//             CompleteMultipartUploadFunc: func(in *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
+// 	               panic("mock out the CompleteMultipartUpload method")
+//             },
+//             CreateMultipartUploadFunc: func(in *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error) {
+// 	               panic("mock out the CreateMultipartUpload method")
+//             },
+//             GetObjectFunc: func(in *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+// 	               panic("mock out the GetObject method")
+//             },
+//             HeadBucketFunc: func(in *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
+// 	               panic("mock out the HeadBucket method")
+//             },
+//             HeadObjectFunc: func(in *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+// 	               panic("mock out the HeadObject method")
+//             },
+//             ListMultipartUploadsFunc: func(in *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error) {
+// 	               panic("mock out the ListMultipartUploads method")
+//             },
+//             ListPartsFunc: func(in *s3.ListPartsInput) (*s3.ListPartsOutput, error) {
+// 	               panic("mock out the ListParts method")
+//             },
+//             UploadPartFunc: func(in *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+// 	               panic("mock out the UploadPart method")
+//             },
+//         }
 //
-// 		// use mockedS3SDKClient in code that requires s3client.S3SDKClient
-// 		// and then make assertions.
+//         // use mockedS3SDKClient in code that requires s3client.S3SDKClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type S3SDKClientMock struct {
 	// CompleteMultipartUploadFunc mocks the CompleteMultipartUpload method.
-	CompleteMultipartUploadFunc func(completeMultipartUploadInput *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
+	CompleteMultipartUploadFunc func(in *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 
 	// CreateMultipartUploadFunc mocks the CreateMultipartUpload method.
-	CreateMultipartUploadFunc func(createMultipartUploadInput *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
+	CreateMultipartUploadFunc func(in *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 
 	// GetObjectFunc mocks the GetObject method.
-	GetObjectFunc func(getObjectInput *s3.GetObjectInput) (*s3.GetObjectOutput, error)
+	GetObjectFunc func(in *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 
 	// HeadBucketFunc mocks the HeadBucket method.
-	HeadBucketFunc func(headBucketInput *s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
+	HeadBucketFunc func(in *s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
+
+	// HeadObjectFunc mocks the HeadObject method.
+	HeadObjectFunc func(in *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 
 	// ListMultipartUploadsFunc mocks the ListMultipartUploads method.
-	ListMultipartUploadsFunc func(listMultipartUploadsInput *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error)
+	ListMultipartUploadsFunc func(in *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error)
 
 	// ListPartsFunc mocks the ListParts method.
-	ListPartsFunc func(listPartsInput *s3.ListPartsInput) (*s3.ListPartsOutput, error)
+	ListPartsFunc func(in *s3.ListPartsInput) (*s3.ListPartsOutput, error)
 
 	// UploadPartFunc mocks the UploadPart method.
-	UploadPartFunc func(uploadPartInput *s3.UploadPartInput) (*s3.UploadPartOutput, error)
+	UploadPartFunc func(in *s3.UploadPartInput) (*s3.UploadPartOutput, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// CompleteMultipartUpload holds details about calls to the CompleteMultipartUpload method.
 		CompleteMultipartUpload []struct {
-			// CompleteMultipartUploadInput is the completeMultipartUploadInput argument value.
-			CompleteMultipartUploadInput *s3.CompleteMultipartUploadInput
+			// In is the in argument value.
+			In *s3.CompleteMultipartUploadInput
 		}
 		// CreateMultipartUpload holds details about calls to the CreateMultipartUpload method.
 		CreateMultipartUpload []struct {
-			// CreateMultipartUploadInput is the createMultipartUploadInput argument value.
-			CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+			// In is the in argument value.
+			In *s3.CreateMultipartUploadInput
 		}
 		// GetObject holds details about calls to the GetObject method.
 		GetObject []struct {
-			// GetObjectInput is the getObjectInput argument value.
-			GetObjectInput *s3.GetObjectInput
+			// In is the in argument value.
+			In *s3.GetObjectInput
 		}
 		// HeadBucket holds details about calls to the HeadBucket method.
 		HeadBucket []struct {
-			// HeadBucketInput is the headBucketInput argument value.
-			HeadBucketInput *s3.HeadBucketInput
+			// In is the in argument value.
+			In *s3.HeadBucketInput
+		}
+		// HeadObject holds details about calls to the HeadObject method.
+		HeadObject []struct {
+			// In is the in argument value.
+			In *s3.HeadObjectInput
 		}
 		// ListMultipartUploads holds details about calls to the ListMultipartUploads method.
 		ListMultipartUploads []struct {
-			// ListMultipartUploadsInput is the listMultipartUploadsInput argument value.
-			ListMultipartUploadsInput *s3.ListMultipartUploadsInput
+			// In is the in argument value.
+			In *s3.ListMultipartUploadsInput
 		}
 		// ListParts holds details about calls to the ListParts method.
 		ListParts []struct {
-			// ListPartsInput is the listPartsInput argument value.
-			ListPartsInput *s3.ListPartsInput
+			// In is the in argument value.
+			In *s3.ListPartsInput
 		}
 		// UploadPart holds details about calls to the UploadPart method.
 		UploadPart []struct {
-			// UploadPartInput is the uploadPartInput argument value.
-			UploadPartInput *s3.UploadPartInput
+			// In is the in argument value.
+			In *s3.UploadPartInput
 		}
 	}
-	lockCompleteMultipartUpload sync.RWMutex
-	lockCreateMultipartUpload   sync.RWMutex
-	lockGetObject               sync.RWMutex
-	lockHeadBucket              sync.RWMutex
-	lockListMultipartUploads    sync.RWMutex
-	lockListParts               sync.RWMutex
-	lockUploadPart              sync.RWMutex
 }
 
 // CompleteMultipartUpload calls CompleteMultipartUploadFunc.
-func (mock *S3SDKClientMock) CompleteMultipartUpload(completeMultipartUploadInput *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
+func (mock *S3SDKClientMock) CompleteMultipartUpload(in *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
 	if mock.CompleteMultipartUploadFunc == nil {
 		panic("S3SDKClientMock.CompleteMultipartUploadFunc: method is nil but S3SDKClient.CompleteMultipartUpload was just called")
 	}
 	callInfo := struct {
-		CompleteMultipartUploadInput *s3.CompleteMultipartUploadInput
+		In *s3.CompleteMultipartUploadInput
 	}{
-		CompleteMultipartUploadInput: completeMultipartUploadInput,
+		In: in,
 	}
-	mock.lockCompleteMultipartUpload.Lock()
+	lockS3SDKClientMockCompleteMultipartUpload.Lock()
 	mock.calls.CompleteMultipartUpload = append(mock.calls.CompleteMultipartUpload, callInfo)
-	mock.lockCompleteMultipartUpload.Unlock()
-	return mock.CompleteMultipartUploadFunc(completeMultipartUploadInput)
+	lockS3SDKClientMockCompleteMultipartUpload.Unlock()
+	return mock.CompleteMultipartUploadFunc(in)
 }
 
 // CompleteMultipartUploadCalls gets all the calls that were made to CompleteMultipartUpload.
 // Check the length with:
 //     len(mockedS3SDKClient.CompleteMultipartUploadCalls())
 func (mock *S3SDKClientMock) CompleteMultipartUploadCalls() []struct {
-	CompleteMultipartUploadInput *s3.CompleteMultipartUploadInput
+	In *s3.CompleteMultipartUploadInput
 } {
 	var calls []struct {
-		CompleteMultipartUploadInput *s3.CompleteMultipartUploadInput
+		In *s3.CompleteMultipartUploadInput
 	}
-	mock.lockCompleteMultipartUpload.RLock()
+	lockS3SDKClientMockCompleteMultipartUpload.RLock()
 	calls = mock.calls.CompleteMultipartUpload
-	mock.lockCompleteMultipartUpload.RUnlock()
+	lockS3SDKClientMockCompleteMultipartUpload.RUnlock()
 	return calls
 }
 
 // CreateMultipartUpload calls CreateMultipartUploadFunc.
-func (mock *S3SDKClientMock) CreateMultipartUpload(createMultipartUploadInput *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error) {
+func (mock *S3SDKClientMock) CreateMultipartUpload(in *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error) {
 	if mock.CreateMultipartUploadFunc == nil {
 		panic("S3SDKClientMock.CreateMultipartUploadFunc: method is nil but S3SDKClient.CreateMultipartUpload was just called")
 	}
 	callInfo := struct {
-		CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+		In *s3.CreateMultipartUploadInput
 	}{
-		CreateMultipartUploadInput: createMultipartUploadInput,
+		In: in,
 	}
-	mock.lockCreateMultipartUpload.Lock()
+	lockS3SDKClientMockCreateMultipartUpload.Lock()
 	mock.calls.CreateMultipartUpload = append(mock.calls.CreateMultipartUpload, callInfo)
-	mock.lockCreateMultipartUpload.Unlock()
-	return mock.CreateMultipartUploadFunc(createMultipartUploadInput)
+	lockS3SDKClientMockCreateMultipartUpload.Unlock()
+	return mock.CreateMultipartUploadFunc(in)
 }
 
 // CreateMultipartUploadCalls gets all the calls that were made to CreateMultipartUpload.
 // Check the length with:
 //     len(mockedS3SDKClient.CreateMultipartUploadCalls())
 func (mock *S3SDKClientMock) CreateMultipartUploadCalls() []struct {
-	CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+	In *s3.CreateMultipartUploadInput
 } {
 	var calls []struct {
-		CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+		In *s3.CreateMultipartUploadInput
 	}
-	mock.lockCreateMultipartUpload.RLock()
+	lockS3SDKClientMockCreateMultipartUpload.RLock()
 	calls = mock.calls.CreateMultipartUpload
-	mock.lockCreateMultipartUpload.RUnlock()
+	lockS3SDKClientMockCreateMultipartUpload.RUnlock()
 	return calls
 }
 
 // GetObject calls GetObjectFunc.
-func (mock *S3SDKClientMock) GetObject(getObjectInput *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+func (mock *S3SDKClientMock) GetObject(in *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	if mock.GetObjectFunc == nil {
 		panic("S3SDKClientMock.GetObjectFunc: method is nil but S3SDKClient.GetObject was just called")
 	}
 	callInfo := struct {
-		GetObjectInput *s3.GetObjectInput
+		In *s3.GetObjectInput
 	}{
-		GetObjectInput: getObjectInput,
+		In: in,
 	}
-	mock.lockGetObject.Lock()
+	lockS3SDKClientMockGetObject.Lock()
 	mock.calls.GetObject = append(mock.calls.GetObject, callInfo)
-	mock.lockGetObject.Unlock()
-	return mock.GetObjectFunc(getObjectInput)
+	lockS3SDKClientMockGetObject.Unlock()
+	return mock.GetObjectFunc(in)
 }
 
 // GetObjectCalls gets all the calls that were made to GetObject.
 // Check the length with:
 //     len(mockedS3SDKClient.GetObjectCalls())
 func (mock *S3SDKClientMock) GetObjectCalls() []struct {
-	GetObjectInput *s3.GetObjectInput
+	In *s3.GetObjectInput
 } {
 	var calls []struct {
-		GetObjectInput *s3.GetObjectInput
+		In *s3.GetObjectInput
 	}
-	mock.lockGetObject.RLock()
+	lockS3SDKClientMockGetObject.RLock()
 	calls = mock.calls.GetObject
-	mock.lockGetObject.RUnlock()
+	lockS3SDKClientMockGetObject.RUnlock()
 	return calls
 }
 
 // HeadBucket calls HeadBucketFunc.
-func (mock *S3SDKClientMock) HeadBucket(headBucketInput *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
+func (mock *S3SDKClientMock) HeadBucket(in *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
 	if mock.HeadBucketFunc == nil {
 		panic("S3SDKClientMock.HeadBucketFunc: method is nil but S3SDKClient.HeadBucket was just called")
 	}
 	callInfo := struct {
-		HeadBucketInput *s3.HeadBucketInput
+		In *s3.HeadBucketInput
 	}{
-		HeadBucketInput: headBucketInput,
+		In: in,
 	}
-	mock.lockHeadBucket.Lock()
+	lockS3SDKClientMockHeadBucket.Lock()
 	mock.calls.HeadBucket = append(mock.calls.HeadBucket, callInfo)
-	mock.lockHeadBucket.Unlock()
-	return mock.HeadBucketFunc(headBucketInput)
+	lockS3SDKClientMockHeadBucket.Unlock()
+	return mock.HeadBucketFunc(in)
 }
 
 // HeadBucketCalls gets all the calls that were made to HeadBucket.
 // Check the length with:
 //     len(mockedS3SDKClient.HeadBucketCalls())
 func (mock *S3SDKClientMock) HeadBucketCalls() []struct {
-	HeadBucketInput *s3.HeadBucketInput
+	In *s3.HeadBucketInput
 } {
 	var calls []struct {
-		HeadBucketInput *s3.HeadBucketInput
+		In *s3.HeadBucketInput
 	}
-	mock.lockHeadBucket.RLock()
+	lockS3SDKClientMockHeadBucket.RLock()
 	calls = mock.calls.HeadBucket
-	mock.lockHeadBucket.RUnlock()
+	lockS3SDKClientMockHeadBucket.RUnlock()
+	return calls
+}
+
+// HeadObject calls HeadObjectFunc.
+func (mock *S3SDKClientMock) HeadObject(in *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	if mock.HeadObjectFunc == nil {
+		panic("S3SDKClientMock.HeadObjectFunc: method is nil but S3SDKClient.HeadObject was just called")
+	}
+	callInfo := struct {
+		In *s3.HeadObjectInput
+	}{
+		In: in,
+	}
+	lockS3SDKClientMockHeadObject.Lock()
+	mock.calls.HeadObject = append(mock.calls.HeadObject, callInfo)
+	lockS3SDKClientMockHeadObject.Unlock()
+	return mock.HeadObjectFunc(in)
+}
+
+// HeadObjectCalls gets all the calls that were made to HeadObject.
+// Check the length with:
+//     len(mockedS3SDKClient.HeadObjectCalls())
+func (mock *S3SDKClientMock) HeadObjectCalls() []struct {
+	In *s3.HeadObjectInput
+} {
+	var calls []struct {
+		In *s3.HeadObjectInput
+	}
+	lockS3SDKClientMockHeadObject.RLock()
+	calls = mock.calls.HeadObject
+	lockS3SDKClientMockHeadObject.RUnlock()
 	return calls
 }
 
 // ListMultipartUploads calls ListMultipartUploadsFunc.
-func (mock *S3SDKClientMock) ListMultipartUploads(listMultipartUploadsInput *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error) {
+func (mock *S3SDKClientMock) ListMultipartUploads(in *s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error) {
 	if mock.ListMultipartUploadsFunc == nil {
 		panic("S3SDKClientMock.ListMultipartUploadsFunc: method is nil but S3SDKClient.ListMultipartUploads was just called")
 	}
 	callInfo := struct {
-		ListMultipartUploadsInput *s3.ListMultipartUploadsInput
+		In *s3.ListMultipartUploadsInput
 	}{
-		ListMultipartUploadsInput: listMultipartUploadsInput,
+		In: in,
 	}
-	mock.lockListMultipartUploads.Lock()
+	lockS3SDKClientMockListMultipartUploads.Lock()
 	mock.calls.ListMultipartUploads = append(mock.calls.ListMultipartUploads, callInfo)
-	mock.lockListMultipartUploads.Unlock()
-	return mock.ListMultipartUploadsFunc(listMultipartUploadsInput)
+	lockS3SDKClientMockListMultipartUploads.Unlock()
+	return mock.ListMultipartUploadsFunc(in)
 }
 
 // ListMultipartUploadsCalls gets all the calls that were made to ListMultipartUploads.
 // Check the length with:
 //     len(mockedS3SDKClient.ListMultipartUploadsCalls())
 func (mock *S3SDKClientMock) ListMultipartUploadsCalls() []struct {
-	ListMultipartUploadsInput *s3.ListMultipartUploadsInput
+	In *s3.ListMultipartUploadsInput
 } {
 	var calls []struct {
-		ListMultipartUploadsInput *s3.ListMultipartUploadsInput
+		In *s3.ListMultipartUploadsInput
 	}
-	mock.lockListMultipartUploads.RLock()
+	lockS3SDKClientMockListMultipartUploads.RLock()
 	calls = mock.calls.ListMultipartUploads
-	mock.lockListMultipartUploads.RUnlock()
+	lockS3SDKClientMockListMultipartUploads.RUnlock()
 	return calls
 }
 
 // ListParts calls ListPartsFunc.
-func (mock *S3SDKClientMock) ListParts(listPartsInput *s3.ListPartsInput) (*s3.ListPartsOutput, error) {
+func (mock *S3SDKClientMock) ListParts(in *s3.ListPartsInput) (*s3.ListPartsOutput, error) {
 	if mock.ListPartsFunc == nil {
 		panic("S3SDKClientMock.ListPartsFunc: method is nil but S3SDKClient.ListParts was just called")
 	}
 	callInfo := struct {
-		ListPartsInput *s3.ListPartsInput
+		In *s3.ListPartsInput
 	}{
-		ListPartsInput: listPartsInput,
+		In: in,
 	}
-	mock.lockListParts.Lock()
+	lockS3SDKClientMockListParts.Lock()
 	mock.calls.ListParts = append(mock.calls.ListParts, callInfo)
-	mock.lockListParts.Unlock()
-	return mock.ListPartsFunc(listPartsInput)
+	lockS3SDKClientMockListParts.Unlock()
+	return mock.ListPartsFunc(in)
 }
 
 // ListPartsCalls gets all the calls that were made to ListParts.
 // Check the length with:
 //     len(mockedS3SDKClient.ListPartsCalls())
 func (mock *S3SDKClientMock) ListPartsCalls() []struct {
-	ListPartsInput *s3.ListPartsInput
+	In *s3.ListPartsInput
 } {
 	var calls []struct {
-		ListPartsInput *s3.ListPartsInput
+		In *s3.ListPartsInput
 	}
-	mock.lockListParts.RLock()
+	lockS3SDKClientMockListParts.RLock()
 	calls = mock.calls.ListParts
-	mock.lockListParts.RUnlock()
+	lockS3SDKClientMockListParts.RUnlock()
 	return calls
 }
 
 // UploadPart calls UploadPartFunc.
-func (mock *S3SDKClientMock) UploadPart(uploadPartInput *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+func (mock *S3SDKClientMock) UploadPart(in *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
 	if mock.UploadPartFunc == nil {
 		panic("S3SDKClientMock.UploadPartFunc: method is nil but S3SDKClient.UploadPart was just called")
 	}
 	callInfo := struct {
-		UploadPartInput *s3.UploadPartInput
+		In *s3.UploadPartInput
 	}{
-		UploadPartInput: uploadPartInput,
+		In: in,
 	}
-	mock.lockUploadPart.Lock()
+	lockS3SDKClientMockUploadPart.Lock()
 	mock.calls.UploadPart = append(mock.calls.UploadPart, callInfo)
-	mock.lockUploadPart.Unlock()
-	return mock.UploadPartFunc(uploadPartInput)
+	lockS3SDKClientMockUploadPart.Unlock()
+	return mock.UploadPartFunc(in)
 }
 
 // UploadPartCalls gets all the calls that were made to UploadPart.
 // Check the length with:
 //     len(mockedS3SDKClient.UploadPartCalls())
 func (mock *S3SDKClientMock) UploadPartCalls() []struct {
-	UploadPartInput *s3.UploadPartInput
+	In *s3.UploadPartInput
 } {
 	var calls []struct {
-		UploadPartInput *s3.UploadPartInput
+		In *s3.UploadPartInput
 	}
-	mock.lockUploadPart.RLock()
+	lockS3SDKClientMockUploadPart.RLock()
 	calls = mock.calls.UploadPart
-	mock.lockUploadPart.RUnlock()
+	lockS3SDKClientMockUploadPart.RUnlock()
 	return calls
 }

--- a/mock/s3-sdk.go
+++ b/mock/s3-sdk.go
@@ -24,6 +24,7 @@ var (
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3SDKClient = &S3SDKClientMock{}
 
+// Example of how to instantiate a mock for testing - this code is automatically generated
 // S3SDKClientMock is a mock implementation of s3client.S3SDKClient.
 //
 //     func TestSomethingThatUsesS3SDKClient(t *testing.T) {

--- a/mock/s3-uploader.go
+++ b/mock/s3-uploader.go
@@ -19,6 +19,7 @@ var (
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3SDKUploader = &S3SDKUploaderMock{}
 
+// Example of how to instantiate a mock for testing - this code is automatically generated
 // S3SDKUploaderMock is a mock implementation of s3client.S3SDKUploader.
 //
 //     func TestSomethingThatUsesS3SDKUploader(t *testing.T) {

--- a/mock/s3-uploader.go
+++ b/mock/s3-uploader.go
@@ -10,128 +10,131 @@ import (
 	"sync"
 )
 
+var (
+	lockS3SDKUploaderMockUpload            sync.RWMutex
+	lockS3SDKUploaderMockUploadWithContext sync.RWMutex
+)
+
 // Ensure, that S3SDKUploaderMock does implement s3client.S3SDKUploader.
 // If this is not the case, regenerate this file with moq.
 var _ s3client.S3SDKUploader = &S3SDKUploaderMock{}
 
 // S3SDKUploaderMock is a mock implementation of s3client.S3SDKUploader.
 //
-// 	func TestSomethingThatUsesS3SDKUploader(t *testing.T) {
+//     func TestSomethingThatUsesS3SDKUploader(t *testing.T) {
 //
-// 		// make and configure a mocked s3client.S3SDKUploader
-// 		mockedS3SDKUploader := &S3SDKUploaderMock{
-// 			UploadFunc: func(uploadInput *s3manager.UploadInput, fns ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
-// 				panic("mock out the Upload method")
-// 			},
-// 			UploadWithContextFunc: func(contextMoqParam context.Context, uploadInput *s3manager.UploadInput, fns ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
-// 				panic("mock out the UploadWithContext method")
-// 			},
-// 		}
+//         // make and configure a mocked s3client.S3SDKUploader
+//         mockedS3SDKUploader := &S3SDKUploaderMock{
+//             UploadFunc: func(in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+// 	               panic("mock out the Upload method")
+//             },
+//             UploadWithContextFunc: func(ctx context.Context, in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+// 	               panic("mock out the UploadWithContext method")
+//             },
+//         }
 //
-// 		// use mockedS3SDKUploader in code that requires s3client.S3SDKUploader
-// 		// and then make assertions.
+//         // use mockedS3SDKUploader in code that requires s3client.S3SDKUploader
+//         // and then make assertions.
 //
-// 	}
+//     }
 type S3SDKUploaderMock struct {
 	// UploadFunc mocks the Upload method.
-	UploadFunc func(uploadInput *s3manager.UploadInput, fns ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+	UploadFunc func(in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 
 	// UploadWithContextFunc mocks the UploadWithContext method.
-	UploadWithContextFunc func(contextMoqParam context.Context, uploadInput *s3manager.UploadInput, fns ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+	UploadWithContextFunc func(ctx context.Context, in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// Upload holds details about calls to the Upload method.
 		Upload []struct {
-			// UploadInput is the uploadInput argument value.
-			UploadInput *s3manager.UploadInput
-			// Fns is the fns argument value.
-			Fns []func(*s3manager.Uploader)
+			// In is the in argument value.
+			In *s3manager.UploadInput
+			// Options is the options argument value.
+			Options []func(*s3manager.Uploader)
 		}
 		// UploadWithContext holds details about calls to the UploadWithContext method.
 		UploadWithContext []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// UploadInput is the uploadInput argument value.
-			UploadInput *s3manager.UploadInput
-			// Fns is the fns argument value.
-			Fns []func(*s3manager.Uploader)
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// In is the in argument value.
+			In *s3manager.UploadInput
+			// Options is the options argument value.
+			Options []func(*s3manager.Uploader)
 		}
 	}
-	lockUpload            sync.RWMutex
-	lockUploadWithContext sync.RWMutex
 }
 
 // Upload calls UploadFunc.
-func (mock *S3SDKUploaderMock) Upload(uploadInput *s3manager.UploadInput, fns ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+func (mock *S3SDKUploaderMock) Upload(in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
 	if mock.UploadFunc == nil {
 		panic("S3SDKUploaderMock.UploadFunc: method is nil but S3SDKUploader.Upload was just called")
 	}
 	callInfo := struct {
-		UploadInput *s3manager.UploadInput
-		Fns         []func(*s3manager.Uploader)
+		In      *s3manager.UploadInput
+		Options []func(*s3manager.Uploader)
 	}{
-		UploadInput: uploadInput,
-		Fns:         fns,
+		In:      in,
+		Options: options,
 	}
-	mock.lockUpload.Lock()
+	lockS3SDKUploaderMockUpload.Lock()
 	mock.calls.Upload = append(mock.calls.Upload, callInfo)
-	mock.lockUpload.Unlock()
-	return mock.UploadFunc(uploadInput, fns...)
+	lockS3SDKUploaderMockUpload.Unlock()
+	return mock.UploadFunc(in, options...)
 }
 
 // UploadCalls gets all the calls that were made to Upload.
 // Check the length with:
 //     len(mockedS3SDKUploader.UploadCalls())
 func (mock *S3SDKUploaderMock) UploadCalls() []struct {
-	UploadInput *s3manager.UploadInput
-	Fns         []func(*s3manager.Uploader)
+	In      *s3manager.UploadInput
+	Options []func(*s3manager.Uploader)
 } {
 	var calls []struct {
-		UploadInput *s3manager.UploadInput
-		Fns         []func(*s3manager.Uploader)
+		In      *s3manager.UploadInput
+		Options []func(*s3manager.Uploader)
 	}
-	mock.lockUpload.RLock()
+	lockS3SDKUploaderMockUpload.RLock()
 	calls = mock.calls.Upload
-	mock.lockUpload.RUnlock()
+	lockS3SDKUploaderMockUpload.RUnlock()
 	return calls
 }
 
 // UploadWithContext calls UploadWithContextFunc.
-func (mock *S3SDKUploaderMock) UploadWithContext(contextMoqParam context.Context, uploadInput *s3manager.UploadInput, fns ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+func (mock *S3SDKUploaderMock) UploadWithContext(ctx context.Context, in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
 	if mock.UploadWithContextFunc == nil {
 		panic("S3SDKUploaderMock.UploadWithContextFunc: method is nil but S3SDKUploader.UploadWithContext was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		UploadInput     *s3manager.UploadInput
-		Fns             []func(*s3manager.Uploader)
+		Ctx     context.Context
+		In      *s3manager.UploadInput
+		Options []func(*s3manager.Uploader)
 	}{
-		ContextMoqParam: contextMoqParam,
-		UploadInput:     uploadInput,
-		Fns:             fns,
+		Ctx:     ctx,
+		In:      in,
+		Options: options,
 	}
-	mock.lockUploadWithContext.Lock()
+	lockS3SDKUploaderMockUploadWithContext.Lock()
 	mock.calls.UploadWithContext = append(mock.calls.UploadWithContext, callInfo)
-	mock.lockUploadWithContext.Unlock()
-	return mock.UploadWithContextFunc(contextMoqParam, uploadInput, fns...)
+	lockS3SDKUploaderMockUploadWithContext.Unlock()
+	return mock.UploadWithContextFunc(ctx, in, options...)
 }
 
 // UploadWithContextCalls gets all the calls that were made to UploadWithContext.
 // Check the length with:
 //     len(mockedS3SDKUploader.UploadWithContextCalls())
 func (mock *S3SDKUploaderMock) UploadWithContextCalls() []struct {
-	ContextMoqParam context.Context
-	UploadInput     *s3manager.UploadInput
-	Fns             []func(*s3manager.Uploader)
+	Ctx     context.Context
+	In      *s3manager.UploadInput
+	Options []func(*s3manager.Uploader)
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		UploadInput     *s3manager.UploadInput
-		Fns             []func(*s3manager.Uploader)
+		Ctx     context.Context
+		In      *s3manager.UploadInput
+		Options []func(*s3manager.Uploader)
 	}
-	mock.lockUploadWithContext.RLock()
+	lockS3SDKUploaderMockUploadWithContext.RLock()
 	calls = mock.calls.UploadWithContext
-	mock.lockUploadWithContext.RUnlock()
+	lockS3SDKUploaderMockUploadWithContext.RUnlock()
 	return calls
 }

--- a/uploader_test.go
+++ b/uploader_test.go
@@ -38,7 +38,7 @@ func TestUpload(t *testing.T) {
 			_, err := uploader.Upload(&s3manager.UploadInput{})
 			So(err, ShouldBeNil)
 			So(len(sdkUploaderMock.UploadCalls()), ShouldEqual, 1)
-			So(*sdkUploaderMock.UploadCalls()[0].UploadInput.Bucket, ShouldEqual, ExistingBucket)
+			So(*sdkUploaderMock.UploadCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
 		})
 
 		Convey("Upload with expected Bucket in parameter uploads the file to the configured S3 bucket using AWS SDK", func() {
@@ -48,7 +48,7 @@ func TestUpload(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 			So(len(sdkUploaderMock.UploadCalls()), ShouldEqual, 1)
-			So(*sdkUploaderMock.UploadCalls()[0].UploadInput.Bucket, ShouldEqual, ExistingBucket)
+			So(*sdkUploaderMock.UploadCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
 		})
 
 		Convey("Tying to upload a file to the wrong S3 bucket results in ErrUnexpectedBucket error", func() {
@@ -84,7 +84,7 @@ func TestUploadWithPSK(t *testing.T) {
 			_, err := uploader.UploadWithPSK(&s3manager.UploadInput{Key: &s3Key}, psk)
 			So(err, ShouldBeNil)
 			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
-			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].UploadInput.Bucket, ShouldEqual, ExistingBucket)
+			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
 		})
 
 		Convey("Upload with expected Bucket in parameter uploads the file to the configured S3 bucket using Crypto Uploader", func() {
@@ -95,7 +95,7 @@ func TestUploadWithPSK(t *testing.T) {
 			}, psk)
 			So(err, ShouldBeNil)
 			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
-			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].UploadInput.Bucket, ShouldEqual, ExistingBucket)
+			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
 		})
 
 		Convey("Tying to upload a file to the wrong S3 bucket results in ErrUnexpectedBucket error", func() {
@@ -130,7 +130,7 @@ func TestUploadWithContext(t *testing.T) {
 			_, err := uploader.UploadWithContext(context.Background(), &s3manager.UploadInput{})
 			So(err, ShouldBeNil)
 			So(len(sdkUploaderWithContextMock.UploadWithContextCalls()), ShouldEqual, 1)
-			So(*sdkUploaderWithContextMock.UploadWithContextCalls()[0].UploadInput.Bucket, ShouldEqual, ExistingBucket)
+			So(*sdkUploaderWithContextMock.UploadWithContextCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
 		})
 
 		Convey("Upload with expected Bucket in parameter uploads the file to the configured S3 bucket using AWS SDK", func() {
@@ -140,7 +140,7 @@ func TestUploadWithContext(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 			So(len(sdkUploaderWithContextMock.UploadWithContextCalls()), ShouldEqual, 1)
-			So(*sdkUploaderWithContextMock.UploadWithContextCalls()[0].UploadInput.Bucket, ShouldEqual, ExistingBucket)
+			So(*sdkUploaderWithContextMock.UploadWithContextCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
 		})
 
 		Convey("Tying to upload a file to the wrong S3 bucket results in ErrUnexpectedBucket error", func() {


### PR DESCRIPTION
### What

Added `Head` call for S3 Objects, so that we can obtain metadata like file size.

Required by [dp-cantabular-csv-exporter](https://github.com/ONSdigital/dp-cantabular-csv-exporter/pull/42)


### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone