### PR TITLE
Implemented UploadWithPSKAndContext in uploader

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"sync"
 
+	"github.com/ONSdigital/dp-s3/crypto"
 	"github.com/ONSdigital/log.go/v2/log"
 
-	"github.com/ONSdigital/s3crypto"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -61,7 +61,7 @@ func NewClientWithSession(bucketName string, s *session.Session) *S3 {
 	sdkClient := s3.New(s)
 
 	// Create crypto client, which allows user to provide a psk
-	cryptoClient := s3crypto.New(s, &s3crypto.Config{HasUserDefinedPSK: true})
+	cryptoClient := crypto.New(s, &crypto.Config{HasUserDefinedPSK: true})
 
 	return InstantiateClient(sdkClient, cryptoClient, bucketName, *region, s)
 }

--- a/crypto/s3crypto.go
+++ b/crypto/s3crypto.go
@@ -1,0 +1,672 @@
+/*
+File copied form s3crypto repository
+Original repo: https://github.com/ONSdigital/s3crypto
+*/
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+const (
+	encryptionKeyHeader = "Pskencrypted"
+
+	maxChunkSize = 5 * 1024 * 1024
+)
+
+// ErrNoPrivateKey is returned when an attempt is made to access a method that requires a private key when it has not been provided
+var ErrNoPrivateKey = errors.New("you have not provided a private key and therefore do not have permission to complete this action")
+
+// ErrNoMetadataPSK is returned when the file you are trying to download is not encrypted
+var ErrNoMetadataPSK = errors.New("no encrypted key found for this file, you are trying to download a file which is not encrypted")
+
+// Config represents the configuration items for the
+// CryptoClient
+type Config struct {
+	PublicKey  *rsa.PublicKey
+	PrivateKey *rsa.PrivateKey
+
+	HasUserDefinedPSK  bool
+	MultipartChunkSize int
+}
+
+// CryptoClient provides a wrapper to the aws-sdk-go S3
+// object
+type CryptoClient struct {
+	s3iface.S3API
+
+	privKey           *rsa.PrivateKey
+	publicKey         *rsa.PublicKey
+	hasUserDefinedPSK bool
+	chunkSize         int
+}
+
+type cryptoReader struct {
+	s3Reader io.ReadCloser
+
+	psk       []byte
+	chunkSize int
+
+	currChunk []byte
+}
+
+func (r *cryptoReader) Read(b []byte) (int, error) {
+	if r.chunkSize == 0 {
+		r.chunkSize = maxChunkSize
+	}
+
+	if len(r.currChunk) == 0 {
+		p := make([]byte, r.chunkSize)
+
+		n, err := io.ReadFull(r.s3Reader, p)
+		if err != nil && err != io.ErrUnexpectedEOF {
+			return n, err
+		}
+
+		unencryptedChunk, err := decryptObjectContent(r.psk, ioutil.NopCloser(bytes.NewReader(p[:n])))
+		if err != nil {
+			return 0, err
+		}
+
+		r.currChunk = unencryptedChunk
+	}
+
+	var n int
+	if len(r.currChunk) >= len(b) {
+		copy(b, r.currChunk[:len(b)])
+		n = len(b)
+		r.currChunk = r.currChunk[len(b):]
+	} else {
+		copy(b, r.currChunk)
+		n = len(r.currChunk)
+		r.currChunk = nil
+	}
+
+	return n, nil
+}
+
+type encryptoReader struct {
+	s3Reader io.Reader
+
+	psk       []byte
+	chunkSize int
+	lastChunk bool
+
+	currChunk []byte
+}
+
+func (r *encryptoReader) Read(b []byte) (int, error) {
+	if r.lastChunk && len(r.currChunk) == 0 {
+		return 0, io.EOF
+	}
+
+	if r.chunkSize == 0 {
+		r.chunkSize = maxChunkSize
+	}
+
+	if len(r.currChunk) == 0 {
+		p := make([]byte, r.chunkSize)
+
+		n, err := io.ReadFull(r.s3Reader, p)
+		if err != nil {
+			if err == io.ErrUnexpectedEOF {
+				r.lastChunk = true
+			} else {
+				return n, err
+			}
+		}
+
+		unencryptedChunk, err := encryptObjectContent(r.psk, bytes.NewReader(p[:n]))
+		if err != nil {
+			return 0, err
+		}
+
+		r.currChunk = unencryptedChunk
+	}
+
+	var n int
+	if len(r.currChunk) >= len(b) {
+		copy(b, r.currChunk[:len(b)])
+		n = len(b)
+		r.currChunk = r.currChunk[len(b):]
+	} else {
+		copy(b, r.currChunk)
+		n = len(r.currChunk)
+		r.currChunk = nil
+	}
+
+	return n, nil
+}
+
+func (r *cryptoReader) Close() error {
+	return r.s3Reader.Close()
+}
+
+// Uploader provides a wrapper to the aws-sdk-go s3manager uploader
+// for encryption
+type Uploader struct {
+	*CryptoClient
+
+	s3uploader *s3manager.Uploader
+}
+
+// New supports the creation of an Encryption supported client
+// with a given aws session and rsa Private Key.
+func New(sess *session.Session, cfg *Config) *CryptoClient {
+	if cfg.MultipartChunkSize == 0 {
+		cfg.MultipartChunkSize = maxChunkSize
+	}
+	cc := &CryptoClient{s3.New(sess), cfg.PrivateKey, cfg.PublicKey, cfg.HasUserDefinedPSK, cfg.MultipartChunkSize}
+
+	if cc.privKey != nil {
+		cc.publicKey = &cc.privKey.PublicKey
+	}
+
+	return cc
+}
+
+// NewUploader creates a new instance of the crypto Uploader
+func NewUploader(sess *session.Session, cfg *Config) *Uploader {
+	cc := &CryptoClient{s3.New(sess), cfg.PrivateKey, cfg.PublicKey, cfg.HasUserDefinedPSK, cfg.MultipartChunkSize}
+
+	if cc.privKey != nil {
+		cc.publicKey = &cc.privKey.PublicKey
+	}
+
+	return &Uploader{
+		CryptoClient: cc,
+
+		s3uploader: s3manager.NewUploader(sess),
+	}
+}
+
+// CreateMultipartUploadRequest wraps the SDK method by creating a PSK which
+// is encrypted using the public key and stored as metadata against the completed
+// object, as well as temporarily being stored as its own object while the Multipart
+// upload is being updated.
+func (c *CryptoClient) CreateMultipartUploadRequest(input *s3.CreateMultipartUploadInput) (req *request.Request, out *s3.CreateMultipartUploadOutput) {
+	req = new(request.Request)
+	if !c.hasUserDefinedPSK {
+		psk := createPSK()
+
+		ekStr, err := c.encryptKey(psk)
+		if err != nil {
+			req.Error = err
+			return
+		}
+
+		input.Metadata = make(map[string]*string)
+		input.Metadata[encryptionKeyHeader] = &ekStr
+
+		if err := c.storeEncryptedKey(input, ekStr); err != nil {
+			req.Error = err
+			return
+		}
+	}
+
+	return c.S3API.CreateMultipartUploadRequest(input)
+}
+
+// CreateMultipartUpload is a wrapper for CreateMultipartUploadRequest
+func (c *CryptoClient) CreateMultipartUpload(input *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error) {
+	req, out := c.CreateMultipartUploadRequest(input)
+	return out, req.Send()
+}
+
+// CreateMultipartUploadWithContext is a wrapper for CreateMultipartUploadRequest with
+// the additional context, and request options support.
+func (c *CryptoClient) CreateMultipartUploadWithContext(ctx aws.Context, input *s3.CreateMultipartUploadInput, opts ...request.Option) (*s3.CreateMultipartUploadOutput, error) {
+	req, out := c.CreateMultipartUploadRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// UploadPartRequest wraps the SDK method by retrieving the encrypted PSK from the temporary
+// object, decrypting the PSK using the private key, before stream encoding the content
+// for the particular part
+func (c *CryptoClient) UploadPartRequest(input *s3.UploadPartInput) (req *request.Request, out *s3.UploadPartOutput) {
+	req = new(request.Request)
+	ekStr, err := c.getEncryptedKey(input)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	psk, err := c.decryptKey(ekStr)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	encryptedContent, err := encryptObjectContent(psk, input.Body)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	input.Body = bytes.NewReader(encryptedContent)
+
+	return c.S3API.UploadPartRequest(input)
+}
+
+// UploadPartRequestWithPSK wraps the SDK method encrypting the part contents with a user defined
+// PSK
+func (c *CryptoClient) UploadPartRequestWithPSK(input *s3.UploadPartInput, psk []byte) (req *request.Request, out *s3.UploadPartOutput) {
+	req = new(request.Request)
+	encryptedContent, err := encryptObjectContent(psk, input.Body)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	input.Body = bytes.NewReader(encryptedContent)
+
+	return c.S3API.UploadPartRequest(input)
+}
+
+// UploadPart is a wrapper for UploadPartRequest
+func (c *CryptoClient) UploadPart(input *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+	req, out := c.UploadPartRequest(input)
+	return out, req.Send()
+}
+
+// UploadPartWithPSK is a wrapper for UploadPartRequestWithPSK
+func (c *CryptoClient) UploadPartWithPSK(input *s3.UploadPartInput, psk []byte) (*s3.UploadPartOutput, error) {
+	req, out := c.UploadPartRequestWithPSK(input, psk)
+	return out, req.Send()
+}
+
+// UploadPartWithContext is a wrapper for UploadPartRequest with
+// the additional context, and request options support.
+func (c *CryptoClient) UploadPartWithContext(ctx aws.Context, input *s3.UploadPartInput, opts ...request.Option) (*s3.UploadPartOutput, error) {
+	req, out := c.UploadPartRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// UploadPartWithContextWithPSK is a wrapper for UploadPartRequestWithPSK with
+// the additional context, and request options support.
+func (c *CryptoClient) UploadPartWithContextWithPSK(ctx aws.Context, input *s3.UploadPartInput, psk []byte, opts ...request.Option) (*s3.UploadPartOutput, error) {
+	req, out := c.UploadPartRequestWithPSK(input, psk)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// PutObjectRequest wraps the SDK method by creating a PSK, encrypting it using the public key,
+// and encrypting the object content using the PSK
+func (c *CryptoClient) PutObjectRequest(input *s3.PutObjectInput) (req *request.Request, out *s3.PutObjectOutput) {
+	req = new(request.Request)
+	psk := createPSK()
+
+	ekStr, err := c.encryptKey(psk)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	input.Metadata = make(map[string]*string)
+	input.Metadata[encryptionKeyHeader] = &ekStr
+
+	encryptedContent, err := encryptObjectContent(psk, input.Body)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	input.Body = bytes.NewReader(encryptedContent)
+
+	return c.S3API.PutObjectRequest(input)
+}
+
+// PutObjectRequestWithPSK wraps the SDK method by encrypting the object content with a user defined PSK
+func (c *CryptoClient) PutObjectRequestWithPSK(input *s3.PutObjectInput, psk []byte) (req *request.Request, out *s3.PutObjectOutput) {
+	req = new(request.Request)
+	encryptedContent, err := encryptObjectContent(psk, input.Body)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	input.Body = bytes.NewReader(encryptedContent)
+
+	return c.S3API.PutObjectRequest(input)
+}
+
+// PutObject is a wrapper for PutObjectRequest
+func (c *CryptoClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	req, out := c.PutObjectRequest(input)
+	return out, req.Send()
+}
+
+// PutObjectWithPSK is a wrapper for PutObjectRequestWithPSK
+func (c *CryptoClient) PutObjectWithPSK(input *s3.PutObjectInput, psk []byte) (*s3.PutObjectOutput, error) {
+	req, out := c.PutObjectRequestWithPSK(input, psk)
+	return out, req.Send()
+}
+
+// PutObjectWithContextWithPSK is a wrapper for PutObjectRequestWithPSK with
+// the additional context, and request options support.
+func (c *CryptoClient) PutObjectWithContextWithPSK(ctx aws.Context, input *s3.PutObjectInput, psk []byte, opts ...request.Option) (*s3.PutObjectOutput, error) {
+	req, out := c.PutObjectRequestWithPSK(input, psk)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// GetObjectRequest wraps the SDK method by retrieving the encrypted PSK from the object metadata.
+// The PSK is then decrypted, and is then used to decrypt the content of the object.
+func (c *CryptoClient) GetObjectRequest(input *s3.GetObjectInput) (req *request.Request, out *s3.GetObjectOutput) {
+	req, out = c.S3API.GetObjectRequest(input)
+
+	err := req.Send()
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	ekStr := out.Metadata[encryptionKeyHeader]
+
+	if ekStr == nil {
+		req.Error = ErrNoMetadataPSK
+		return
+	}
+
+	psk, err := c.decryptKey(*ekStr)
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	var content io.Reader
+	if c.chunkSize > 0 {
+		content, err = decryptObjectContentChunks(c.chunkSize, psk, out.Body)
+	} else {
+		content, err = decryptObjectContentChunks(maxChunkSize, psk, out.Body)
+	}
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	out.Body = ioutil.NopCloser(content)
+
+	return
+}
+
+// GetObjectRequestWithPSK wraps the SDK method by decrypting the retrieved object content with the given PSK
+func (c *CryptoClient) GetObjectRequestWithPSK(input *s3.GetObjectInput, psk []byte) (req *request.Request, out *s3.GetObjectOutput) {
+	req, out = c.S3API.GetObjectRequest(input)
+
+	err := req.Send()
+	if err != nil {
+		req.Error = err
+		return
+	}
+
+	out.Body = &cryptoReader{
+		s3Reader:  out.Body,
+		psk:       psk,
+		chunkSize: c.chunkSize,
+	}
+
+	return
+}
+
+// GetObject is a wrapper for GetObjectRequest
+func (c *CryptoClient) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	req, out := c.GetObjectRequest(input)
+	return out, req.Error
+}
+
+// GetObjectWithPSK is a wrapper for GetObjectRequestWithPSK
+func (c *CryptoClient) GetObjectWithPSK(input *s3.GetObjectInput, psk []byte) (*s3.GetObjectOutput, error) {
+	req, out := c.GetObjectRequestWithPSK(input, psk)
+	return out, req.Error
+}
+
+// GetObjectWithContext is a wrapper for GetObjectRequest with
+// the additional context, and request options support.
+func (c *CryptoClient) GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
+	req, out := c.GetObjectRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Error
+}
+
+// GetObjectWithContextWithPSK is a wrapper for GetObjectRequestWithPSK with
+// the additional context, and request options support.
+func (c *CryptoClient) GetObjectWithContextWithPSK(ctx aws.Context, input *s3.GetObjectInput, psk []byte, opts ...request.Option) (*s3.GetObjectOutput, error) {
+	req, out := c.GetObjectRequestWithPSK(input, psk)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Error
+}
+
+// CompleteMultipartUploadRequest wraps the SDK method by removing the temporarily stored encrypted
+// PSK object.
+func (c *CryptoClient) CompleteMultipartUploadRequest(input *s3.CompleteMultipartUploadInput) (req *request.Request, out *s3.CompleteMultipartUploadOutput) {
+	req = new(request.Request)
+	if !c.hasUserDefinedPSK {
+		if err := c.removeEncryptedKey(input); err != nil {
+			req.Error = err
+		}
+	}
+
+	return c.S3API.CompleteMultipartUploadRequest(input)
+}
+
+// CompleteMultipartUpload is a wrapper for CompleteMultipartUploadRequest
+func (c *CryptoClient) CompleteMultipartUpload(input *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
+	req, out := c.CompleteMultipartUploadRequest(input)
+	return out, req.Send()
+}
+
+// CompleteMultipartUploadWithContext is a wrapper for CompleteMultipartUploadRequest with
+// the additional context, and request options support.
+func (c *CryptoClient) CompleteMultipartUploadWithContext(ctx aws.Context, input *s3.CompleteMultipartUploadInput, opts ...request.Option) (*s3.CompleteMultipartUploadOutput, error) {
+	req, out := c.CompleteMultipartUploadRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+func (c *CryptoClient) storeEncryptedKey(input *s3.CreateMultipartUploadInput, key string) error {
+	keyFileName := *input.Key + ".key"
+
+	objectInput := &s3.PutObjectInput{
+		Body:   aws.ReadSeekCloser(strings.NewReader(key)),
+		Bucket: input.Bucket,
+		Key:    &keyFileName,
+	}
+
+	_, err := c.S3API.PutObject(objectInput)
+	return err
+}
+
+func (c *CryptoClient) getEncryptedKey(input *s3.UploadPartInput) (string, error) {
+	keyFileName := *input.Key + ".key"
+
+	objectInput := &s3.GetObjectInput{
+		Bucket: input.Bucket,
+		Key:    &keyFileName,
+	}
+
+	objectOutput, err := c.S3API.GetObject(objectInput)
+	if err != nil {
+		return "", err
+	}
+
+	key, err := ioutil.ReadAll(objectOutput.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(key), nil
+}
+
+func (c *CryptoClient) removeEncryptedKey(input *s3.CompleteMultipartUploadInput) error {
+	keyFileName := *input.Key + ".key"
+
+	objectInput := &s3.DeleteObjectInput{
+		Bucket: input.Bucket,
+		Key:    &keyFileName,
+	}
+
+	_, err := c.S3API.DeleteObject(objectInput)
+	return err
+}
+
+func (c *CryptoClient) encryptKey(psk []byte) (string, error) {
+	hash := sha1.New()
+	encryptedKey, err := rsa.EncryptOAEP(hash, rand.Reader, c.publicKey, psk, []byte(""))
+	if err != nil {
+		return "", err
+	}
+
+	ekStr := hex.EncodeToString(encryptedKey)
+	return ekStr, nil
+}
+
+func (c *CryptoClient) decryptKey(encryptedKeyHex string) ([]byte, error) {
+	if c.privKey == nil {
+		return nil, ErrNoPrivateKey
+	}
+
+	encryptedKey, err := hex.DecodeString(encryptedKeyHex)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := sha1.New()
+	return rsa.DecryptOAEP(hash, rand.Reader, c.privKey, encryptedKey, []byte(""))
+}
+
+// Upload provides a wrapper for the sdk method with encryption
+func (u *Uploader) Upload(input *s3manager.UploadInput) (output *s3manager.UploadOutput, err error) {
+	psk := createPSK()
+
+	ekStr, err := u.CryptoClient.encryptKey(psk)
+	if err != nil {
+		return
+	}
+
+	input.Metadata = make(map[string]*string)
+	input.Metadata[encryptionKeyHeader] = &ekStr
+
+	encryptedContent, err := encryptObjectContent(psk, input.Body)
+	if err != nil {
+		return
+	}
+
+	input.Body = bytes.NewReader(encryptedContent)
+
+	return u.s3uploader.Upload(input)
+}
+
+// UploadWithPSK allows you to encrypt the file with a given psk
+func (u *Uploader) UploadWithPSK(ctx context.Context, input *s3manager.UploadInput, psk []byte) (output *s3manager.UploadOutput, err error) {
+	input.Body = &encryptoReader{
+		psk:      psk,
+		s3Reader: input.Body,
+	}
+
+	if ctx != nil {
+		return u.s3uploader.UploadWithContext(ctx, input)
+	}
+	return u.s3uploader.Upload(input)
+}
+
+func encryptObjectContent(psk []byte, b io.Reader) ([]byte, error) {
+	unencryptedBytes, err := ioutil.ReadAll(b)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(psk)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedBytes := make([]byte, len(unencryptedBytes))
+
+	stream := cipher.NewCFBEncrypter(block, psk)
+
+	stream.XORKeyStream(encryptedBytes, unencryptedBytes)
+
+	return encryptedBytes, nil
+}
+
+func decryptObjectContentChunks(size int, psk []byte, r io.ReadCloser) (io.Reader, error) {
+
+	p := make([]byte, size)
+
+	buf := &bytes.Buffer{}
+	for {
+		n, err := io.ReadFull(r, p)
+		if err != nil && err != io.ErrUnexpectedEOF {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+
+		unencryptedChunk, err := decryptObjectContent(psk, ioutil.NopCloser(bytes.NewReader(p[:n])))
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = buf.Write(unencryptedChunk)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buf, nil
+}
+
+func decryptObjectContent(psk []byte, b io.ReadCloser) ([]byte, error) {
+	encryptedBytes, err := ioutil.ReadAll(b)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(psk)
+	if err != nil {
+		return nil, err
+	}
+
+	stream := cipher.NewCFBDecrypter(block, psk)
+
+	unencryptedBytes := make([]byte, len(encryptedBytes))
+	stream.XORKeyStream(unencryptedBytes, encryptedBytes)
+
+	return unencryptedBytes, nil
+}
+
+func createPSK() []byte {
+	key := make([]byte, 16)
+	rand.Read(key)
+
+	return key
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/log.go/v2 v2.0.5
-	github.com/ONSdigital/s3crypto v0.0.0-20180725145621-f8943119a487
 	github.com/aws/aws-sdk-go v1.40.13
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
 github.com/ONSdigital/log.go/v2 v2.0.5 h1:kl2lF0vr3BQDwPTAUcarDvX4Um3uE3fjVRfLoHAarBc=
 github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
-github.com/ONSdigital/s3crypto v0.0.0-20180725145621-f8943119a487 h1:gQ8g6w/Pe2e1bt1Ht//tQXPxNpwHFcPbi09MRGKH0eM=
-github.com/ONSdigital/s3crypto v0.0.0-20180725145621-f8943119a487/go.mod h1:sYVkbMGvEplxktSXXSOVMQgGOuhqIXX5qBns81v1vas=
 github.com/aws/aws-sdk-go v1.40.13 h1:QC1uYnUqVjhw0DEoIkmloErlno8t7NAtxFU+4fLWRTU=
 github.com/aws/aws-sdk-go v1.40.13/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/ifaces.go
+++ b/ifaces.go
@@ -39,5 +39,5 @@ type S3SDKUploader interface {
 
 // S3CryptoUploader represents the s3crypto Uploader with methods required to upload parts with encryption
 type S3CryptoUploader interface {
-	UploadWithPSK(in *s3manager.UploadInput, psk []byte) (out *s3manager.UploadOutput, err error)
+	UploadWithPSK(ctx context.Context, in *s3manager.UploadInput, psk []byte) (out *s3manager.UploadOutput, err error)
 }

--- a/mock/s3-crypto-uploader.go
+++ b/mock/s3-crypto-uploader.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	"context"
 	"github.com/ONSdigital/dp-s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"sync"
@@ -24,7 +25,7 @@ var _ s3client.S3CryptoUploader = &S3CryptoUploaderMock{}
 //
 //         // make and configure a mocked s3client.S3CryptoUploader
 //         mockedS3CryptoUploader := &S3CryptoUploaderMock{
-//             UploadWithPSKFunc: func(in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
+//             UploadWithPSKFunc: func(ctx context.Context, in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
 // 	               panic("mock out the UploadWithPSK method")
 //             },
 //         }
@@ -35,12 +36,14 @@ var _ s3client.S3CryptoUploader = &S3CryptoUploaderMock{}
 //     }
 type S3CryptoUploaderMock struct {
 	// UploadWithPSKFunc mocks the UploadWithPSK method.
-	UploadWithPSKFunc func(in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error)
+	UploadWithPSKFunc func(ctx context.Context, in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// UploadWithPSK holds details about calls to the UploadWithPSK method.
 		UploadWithPSK []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// In is the in argument value.
 			In *s3manager.UploadInput
 			// Psk is the psk argument value.
@@ -50,31 +53,35 @@ type S3CryptoUploaderMock struct {
 }
 
 // UploadWithPSK calls UploadWithPSKFunc.
-func (mock *S3CryptoUploaderMock) UploadWithPSK(in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
+func (mock *S3CryptoUploaderMock) UploadWithPSK(ctx context.Context, in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
 	if mock.UploadWithPSKFunc == nil {
 		panic("S3CryptoUploaderMock.UploadWithPSKFunc: method is nil but S3CryptoUploader.UploadWithPSK was just called")
 	}
 	callInfo := struct {
+		Ctx context.Context
 		In  *s3manager.UploadInput
 		Psk []byte
 	}{
+		Ctx: ctx,
 		In:  in,
 		Psk: psk,
 	}
 	lockS3CryptoUploaderMockUploadWithPSK.Lock()
 	mock.calls.UploadWithPSK = append(mock.calls.UploadWithPSK, callInfo)
 	lockS3CryptoUploaderMockUploadWithPSK.Unlock()
-	return mock.UploadWithPSKFunc(in, psk)
+	return mock.UploadWithPSKFunc(ctx, in, psk)
 }
 
 // UploadWithPSKCalls gets all the calls that were made to UploadWithPSK.
 // Check the length with:
 //     len(mockedS3CryptoUploader.UploadWithPSKCalls())
 func (mock *S3CryptoUploaderMock) UploadWithPSKCalls() []struct {
+	Ctx context.Context
 	In  *s3manager.UploadInput
 	Psk []byte
 } {
 	var calls []struct {
+		Ctx context.Context
 		In  *s3manager.UploadInput
 		Psk []byte
 	}

--- a/uploader_test.go
+++ b/uploader_test.go
@@ -3,6 +3,7 @@ package s3client_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	s3client "github.com/ONSdigital/dp-s3"
@@ -12,150 +13,376 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func uploadOK(uploadInput *s3manager.UploadInput, in2 ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
-	return &s3manager.UploadOutput{}, nil
-}
-
-func uploadWithPskOk(uploadInput *s3manager.UploadInput, in2 []byte) (*s3manager.UploadOutput, error) {
-	return &s3manager.UploadOutput{}, nil
-}
-
-func uploadWithContextOK(ctx context.Context, uploadInput *s3manager.UploadInput, in2 ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
-	return &s3manager.UploadOutput{}, nil
-}
+var (
+	testS3Key  = "test/s3Key.csv"
+	testBucket = "my-bucket"
+)
 
 func TestUpload(t *testing.T) {
-
-	Convey("Given an Uploader configured without user-defined psk", t, func() {
+	Convey("Given an Uploader configured with an sdk uploader", t, func() {
 		sdkMock := &mock.S3SDKClientMock{}
-		s3Cli := s3client.InstantiateClient(sdkMock, nil, ExistingBucket, ExpectedRegion, nil)
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
 		sdkUploaderMock := &mock.S3SDKUploaderMock{
-			UploadFunc: uploadOK,
+			UploadFunc: func(in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+				return nil, nil
+			},
 		}
 		uploader := s3client.InstantiateUploader(s3Cli, sdkUploaderMock, nil)
 
-		Convey("Upload with no bucket in parameter uploads the file to the configured S3 bucket using AWS SDK", func() {
-			_, err := uploader.Upload(&s3manager.UploadInput{})
+		Convey("Calling Upload with a valid s3 key results in sdk Upload being called as expected", func() {
+			_, err := uploader.Upload(&s3manager.UploadInput{Key: &testS3Key})
 			So(err, ShouldBeNil)
 			So(len(sdkUploaderMock.UploadCalls()), ShouldEqual, 1)
-			So(*sdkUploaderMock.UploadCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
+			So(*sdkUploaderMock.UploadCalls()[0].In.Bucket, ShouldEqual, testBucket)
 		})
 
-		Convey("Upload with expected Bucket in parameter uploads the file to the configured S3 bucket using AWS SDK", func() {
-			validBucket := ExistingBucket
-			_, err := uploader.Upload(&s3manager.UploadInput{
-				Bucket: &validBucket,
-			})
-			So(err, ShouldBeNil)
-			So(len(sdkUploaderMock.UploadCalls()), ShouldEqual, 1)
-			So(*sdkUploaderMock.UploadCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
-		})
-
-		Convey("Tying to upload a file to the wrong S3 bucket results in ErrUnexpectedBucket error", func() {
-			wrongBucket := "someBucket"
-			_, err := uploader.Upload(&s3manager.UploadInput{
-				Bucket: &wrongBucket,
-			})
+		Convey("Calling Upload with nil input returns the expected error", func() {
+			_, err := uploader.Upload(nil)
 			So(err, ShouldResemble, s3client.NewError(
-				errors.New("unexpected bucket name provided in upload input"),
+				fmt.Errorf("validation error for Upload: %w",
+					errors.New("nil input provided"),
+				),
 				log.Data{
-					"client_bucket_name": "csv-exported",
-					"input_bucket_name":  "someBucket",
+					"bucket_name": testBucket,
 				},
 			))
 			So(len(sdkUploaderMock.UploadCalls()), ShouldEqual, 0)
 		})
 	})
-}
 
-func TestUploadWithPSK(t *testing.T) {
-	s3Key := "my/s3/key"
-
-	Convey("Given an Uploader configured with user-defined psk", t, func() {
-		psk := []byte("test psk")
+	Convey("Given an SDK Uploader that fails to upload", t, func() {
+		errUploader := errors.New("failed to upload file")
 		sdkMock := &mock.S3SDKClientMock{}
-		s3Cli := s3client.InstantiateClient(sdkMock, nil, ExistingBucket, ExpectedRegion, nil)
-		cryptoUploaderMock := &mock.S3CryptoUploaderMock{
-			UploadWithPSKFunc: uploadWithPskOk,
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
+		sdkUploaderMock := &mock.S3SDKUploaderMock{
+			UploadFunc: func(in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+				return nil, errUploader
+			},
 		}
-		uploader := s3client.InstantiateUploader(s3Cli, nil, cryptoUploaderMock)
+		uploader := s3client.InstantiateUploader(s3Cli, sdkUploaderMock, nil)
 
-		Convey("UploadWithPSK with no bucket in parameter uploads the file to the configured S3 bucket using Crypto Uploader", func() {
-			_, err := uploader.UploadWithPSK(&s3manager.UploadInput{Key: &s3Key}, psk)
-			So(err, ShouldBeNil)
-			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
-			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
-		})
-
-		Convey("Upload with expected Bucket in parameter uploads the file to the configured S3 bucket using Crypto Uploader", func() {
-			validBucket := ExistingBucket
-			_, err := uploader.UploadWithPSK(&s3manager.UploadInput{
-				Key:    &s3Key,
-				Bucket: &validBucket,
-			}, psk)
-			So(err, ShouldBeNil)
-			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
-			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
-		})
-
-		Convey("Tying to upload a file to the wrong S3 bucket results in ErrUnexpectedBucket error", func() {
-			wrongBucket := "someBucket"
-			_, err := uploader.UploadWithPSK(&s3manager.UploadInput{
-				Key:    &s3Key,
-				Bucket: &wrongBucket,
-			}, psk)
+		Convey("Calling Upload with a valid s3 key results in the expected error being returned", func() {
+			_, err := uploader.Upload(&s3manager.UploadInput{Key: &testS3Key})
 			So(err, ShouldResemble, s3client.NewError(
-				errors.New("unexpected bucket name provided in upload input"),
+				fmt.Errorf("failed to upload: %w", errUploader),
 				log.Data{
-					"client_bucket_name": "csv-exported",
-					"input_bucket_name":  "someBucket",
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
 				},
 			))
-			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 0)
+			So(len(sdkUploaderMock.UploadCalls()), ShouldEqual, 1)
+			So(*sdkUploaderMock.UploadCalls()[0].In.Bucket, ShouldEqual, testBucket)
 		})
 	})
 }
 
 func TestUploadWithContext(t *testing.T) {
+	ctx := context.Background()
 
-	Convey("Given an Uploader configured without user-defined psk", t, func() {
+	Convey("Given an Uploader configured with an sdk uploader", t, func() {
 		sdkMock := &mock.S3SDKClientMock{}
-		s3Cli := s3client.InstantiateClient(sdkMock, nil, ExistingBucket, ExpectedRegion, nil)
-		sdkUploaderWithContextMock := &mock.S3SDKUploaderMock{
-			UploadWithContextFunc: uploadWithContextOK,
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
+		sdkUploaderMock := &mock.S3SDKUploaderMock{
+			UploadWithContextFunc: func(ctx context.Context, in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+				return nil, nil
+			},
 		}
-		uploader := s3client.InstantiateUploader(s3Cli, sdkUploaderWithContextMock, nil)
+		uploader := s3client.InstantiateUploader(s3Cli, sdkUploaderMock, nil)
 
-		Convey("Upload with no bucket in parameter uploads the file to the configured S3 bucket using AWS SDK", func() {
-			_, err := uploader.UploadWithContext(context.Background(), &s3manager.UploadInput{})
+		Convey("Calling UploadWithContext with a valid s3 key and context results in sdk UploadWithContext being called as expected", func() {
+			_, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{Key: &testS3Key})
 			So(err, ShouldBeNil)
-			So(len(sdkUploaderWithContextMock.UploadWithContextCalls()), ShouldEqual, 1)
-			So(*sdkUploaderWithContextMock.UploadWithContextCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
+			So(len(sdkUploaderMock.UploadWithContextCalls()), ShouldEqual, 1)
+			So(*sdkUploaderMock.UploadWithContextCalls()[0].In.Bucket, ShouldEqual, testBucket)
+			So(sdkUploaderMock.UploadWithContextCalls()[0].Ctx, ShouldEqual, ctx)
 		})
 
-		Convey("Upload with expected Bucket in parameter uploads the file to the configured S3 bucket using AWS SDK", func() {
-			validBucket := ExistingBucket
-			_, err := uploader.UploadWithContext(context.Background(), &s3manager.UploadInput{
-				Bucket: &validBucket,
-			})
-			So(err, ShouldBeNil)
-			So(len(sdkUploaderWithContextMock.UploadWithContextCalls()), ShouldEqual, 1)
-			So(*sdkUploaderWithContextMock.UploadWithContextCalls()[0].In.Bucket, ShouldEqual, ExistingBucket)
-		})
-
-		Convey("Tying to upload a file to the wrong S3 bucket results in ErrUnexpectedBucket error", func() {
-			wrongBucket := "someBucket"
-			_, err := uploader.UploadWithContext(context.Background(), &s3manager.UploadInput{
-				Bucket: &wrongBucket,
-			})
+		Convey("Calling UploadWithContext with nil context returns the expected error", func() {
+			_, err := uploader.UploadWithContext(nil, &s3manager.UploadInput{Key: &testS3Key})
 			So(err, ShouldResemble, s3client.NewError(
-				errors.New("unexpected bucket name provided in upload input"),
+				errors.New("nil context provided to UploadWithContext"),
 				log.Data{
-					"client_bucket_name": "csv-exported",
-					"input_bucket_name":  "someBucket",
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
 				},
 			))
-			So(len(sdkUploaderWithContextMock.UploadWithContextCalls()), ShouldEqual, 0)
+			So(len(sdkUploaderMock.UploadWithContextCalls()), ShouldEqual, 0)
+		})
+
+		Convey("Calling UploadWithContext with nil input returns the expected error", func() {
+			_, err := uploader.UploadWithContext(ctx, nil)
+			So(err, ShouldResemble, s3client.NewError(
+				fmt.Errorf("validation error for UploadWithContext: %w",
+					errors.New("nil input provided"),
+				),
+				log.Data{
+					"bucket_name": testBucket,
+				},
+			))
+			So(len(sdkUploaderMock.UploadWithContextCalls()), ShouldEqual, 0)
+		})
+	})
+
+	Convey("Given an SDK Uploader that fails to upload", t, func() {
+		errUploader := errors.New("failed to upload file")
+		sdkMock := &mock.S3SDKClientMock{}
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
+		sdkUploaderMock := &mock.S3SDKUploaderMock{
+			UploadWithContextFunc: func(ctx context.Context, in *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+				return nil, errUploader
+			},
+		}
+		uploader := s3client.InstantiateUploader(s3Cli, sdkUploaderMock, nil)
+
+		Convey("Calling UploadWithContext with a valid s3 key and context results in the expected error being returned", func() {
+			_, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{Key: &testS3Key})
+			So(err, ShouldResemble, s3client.NewError(
+				fmt.Errorf("failed to upload with context: %w", errUploader),
+				log.Data{
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
+				},
+			))
+			So(len(sdkUploaderMock.UploadWithContextCalls()), ShouldEqual, 1)
+			So(*sdkUploaderMock.UploadWithContextCalls()[0].In.Bucket, ShouldEqual, testBucket)
+			So(sdkUploaderMock.UploadWithContextCalls()[0].Ctx, ShouldEqual, ctx)
+		})
+	})
+}
+
+func TestUploadWithPSK(t *testing.T) {
+	Convey("Given an Uploader configured with user-defined psk", t, func() {
+		psk := []byte("test psk")
+		sdkMock := &mock.S3SDKClientMock{}
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
+		cryptoUploaderMock := &mock.S3CryptoUploaderMock{
+			UploadWithPSKFunc: func(ctx context.Context, in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
+				return &s3manager.UploadOutput{}, nil
+			},
+		}
+		uploader := s3client.InstantiateUploader(s3Cli, nil, cryptoUploaderMock)
+
+		Convey("Calling UploadWithPSK with a valid s3 key results in crypto UploadWithPSK being called as expected", func() {
+			_, err := uploader.UploadWithPSK(&s3manager.UploadInput{Key: &testS3Key}, psk)
+			So(err, ShouldBeNil)
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
+			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, testBucket)
+			So(cryptoUploaderMock.UploadWithPSKCalls()[0].Ctx, ShouldEqual, nil)
+		})
+
+		Convey("Calling UploadWithPSK with nil psk returns the expected error", func() {
+			_, err := uploader.UploadWithPSK(&s3manager.UploadInput{Key: &testS3Key}, nil)
+			So(err, ShouldResemble, s3client.NewError(
+				errors.New("nil or empty psk provided to UploadWithPSK"),
+				log.Data{
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
+				},
+			))
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 0)
+		})
+
+		Convey("Calling UploadWithPSK with nil input returns the expected error", func() {
+			_, err := uploader.UploadWithPSK(nil, psk)
+			So(err, ShouldResemble, s3client.NewError(
+				fmt.Errorf("validation error for UploadWithPSK: %w",
+					errors.New("nil input provided"),
+				),
+				log.Data{
+					"bucket_name": testBucket,
+				},
+			))
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 0)
+		})
+	})
+
+	Convey("Given an Uploader configured with user-defined psk that fails to upload", t, func() {
+		errCryptoUploader := errors.New("failed to upload file")
+		psk := []byte("test psk")
+		sdkMock := &mock.S3SDKClientMock{}
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
+		cryptoUploaderMock := &mock.S3CryptoUploaderMock{
+			UploadWithPSKFunc: func(ctx context.Context, in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
+				return nil, errCryptoUploader
+			},
+		}
+		uploader := s3client.InstantiateUploader(s3Cli, nil, cryptoUploaderMock)
+
+		Convey("Calling UploadWithPSK with a valid s3 key and context results in the expected error being returned", func() {
+			_, err := uploader.UploadWithPSK(&s3manager.UploadInput{Key: &testS3Key}, psk)
+			So(err, ShouldResemble, s3client.NewError(
+				fmt.Errorf("failed to upload with psk: %w", errCryptoUploader),
+				log.Data{
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
+				},
+			))
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
+			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, testBucket)
+			So(cryptoUploaderMock.UploadWithPSKCalls()[0].Ctx, ShouldEqual, nil)
+		})
+	})
+}
+
+func TestUploadWithPSKAndContext(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given an Uploader configured with user-defined psk", t, func() {
+		psk := []byte("test psk")
+		sdkMock := &mock.S3SDKClientMock{}
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
+		cryptoUploaderMock := &mock.S3CryptoUploaderMock{
+			UploadWithPSKFunc: func(ctx context.Context, in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
+				return &s3manager.UploadOutput{}, nil
+			},
+		}
+		uploader := s3client.InstantiateUploader(s3Cli, nil, cryptoUploaderMock)
+
+		Convey("Calling UploadWithPSKAndContext with a valid s3 key and context results in crypto UploadWithPSK being called as expected", func() {
+			_, err := uploader.UploadWithPSKAndContext(ctx, &s3manager.UploadInput{Key: &testS3Key}, psk)
+			So(err, ShouldBeNil)
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
+			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, testBucket)
+			So(cryptoUploaderMock.UploadWithPSKCalls()[0].Ctx, ShouldEqual, ctx)
+		})
+
+		Convey("Calling UploadWithPSKAndContext with nil context returns the expected error", func() {
+			_, err := uploader.UploadWithPSKAndContext(nil, &s3manager.UploadInput{Key: &testS3Key}, psk)
+			So(err, ShouldResemble, s3client.NewError(
+				errors.New("nil context provided to UploadWithPSKAndContext"),
+				log.Data{
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
+				},
+			))
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 0)
+		})
+
+		Convey("Calling UploadWithPSKAndContext with nil psk returns the expected error", func() {
+			_, err := uploader.UploadWithPSKAndContext(ctx, &s3manager.UploadInput{Key: &testS3Key}, nil)
+			So(err, ShouldResemble, s3client.NewError(
+				errors.New("nil or empty psk provided to UploadWithPSKAndContext"),
+				log.Data{
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
+				},
+			))
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 0)
+		})
+
+		Convey("Calling UploadWithPSKAndContext with nil input returns the expected error", func() {
+			_, err := uploader.UploadWithPSKAndContext(ctx, nil, psk)
+			So(err, ShouldResemble, s3client.NewError(
+				fmt.Errorf("validation error for UploadWithPSKAndContext: %w",
+					errors.New("nil input provided"),
+				),
+				log.Data{
+					"bucket_name": testBucket,
+				},
+			))
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 0)
+		})
+	})
+
+	Convey("Given an Uploader configured with user-defined psk that fails to upload", t, func() {
+		errCryptoUploader := errors.New("failed to upload file")
+		psk := []byte("test psk")
+		sdkMock := &mock.S3SDKClientMock{}
+		s3Cli := s3client.InstantiateClient(sdkMock, nil, testBucket, ExpectedRegion, nil)
+		cryptoUploaderMock := &mock.S3CryptoUploaderMock{
+			UploadWithPSKFunc: func(ctx context.Context, in *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
+				return nil, errCryptoUploader
+			},
+		}
+		uploader := s3client.InstantiateUploader(s3Cli, nil, cryptoUploaderMock)
+
+		Convey("Calling UploadWithPSKAndContext with a valid s3 key and context results in the expected error being returned", func() {
+			_, err := uploader.UploadWithPSKAndContext(ctx, &s3manager.UploadInput{Key: &testS3Key}, psk)
+			So(err, ShouldResemble, s3client.NewError(
+				fmt.Errorf("failed to upload with psk: %w", errCryptoUploader),
+				log.Data{
+					"bucket_name": testBucket,
+					"s3_key":      testS3Key,
+				},
+			))
+			So(len(cryptoUploaderMock.UploadWithPSKCalls()), ShouldEqual, 1)
+			So(*cryptoUploaderMock.UploadWithPSKCalls()[0].In.Bucket, ShouldEqual, testBucket)
+			So(cryptoUploaderMock.UploadWithPSKCalls()[0].Ctx, ShouldEqual, ctx)
+		})
+	})
+}
+
+func TestValidateInput(t *testing.T) {
+	u := s3client.Uploader{
+		S3: s3client.InstantiateClient(nil, nil, testBucket, "", nil),
+	}
+
+	Convey("validating an input with only an s3 key is successful with the expected logData", t, func() {
+		logData, err := u.ValidateInput(&s3manager.UploadInput{
+			Key: &testS3Key,
+		})
+
+		So(err, ShouldBeNil)
+		So(logData, ShouldResemble, log.Data{
+			"bucket_name": testBucket,
+			"s3_key":      testS3Key,
+		})
+	})
+
+	Convey("validating an input with an s3 key and the expected bucket is successful with the expected logData", t, func() {
+		logData, err := u.ValidateInput(&s3manager.UploadInput{
+			Key:    &testS3Key,
+			Bucket: &testBucket,
+		})
+
+		So(err, ShouldBeNil)
+		So(logData, ShouldResemble, log.Data{
+			"bucket_name": testBucket,
+			"s3_key":      testS3Key,
+		})
+	})
+
+	Convey("validating a nil input fails with the expected error and logData", t, func() {
+		logData, err := u.ValidateInput(nil)
+
+		So(err, ShouldResemble, errors.New("nil input provided"))
+		So(logData, ShouldResemble, log.Data{
+			"bucket_name": testBucket,
+		})
+	})
+
+	Convey("validating an input without s3 key fails with the expected error and logData", t, func() {
+		logData, err := u.ValidateInput(&s3manager.UploadInput{})
+
+		So(err, ShouldResemble, errors.New("nil or empty s3 key provided in input"))
+		So(logData, ShouldResemble, log.Data{
+			"bucket_name": testBucket,
+		})
+	})
+
+	Convey("validating an input without s3 key fails with the expected error and logData", t, func() {
+		emptyKey := ""
+		logData, err := u.ValidateInput(&s3manager.UploadInput{
+			Key: &emptyKey,
+		})
+		So(err, ShouldResemble, errors.New("nil or empty s3 key provided in input"))
+		So(logData, ShouldResemble, log.Data{
+			"bucket_name": testBucket,
+		})
+	})
+
+	Convey("validating an input with an s3 key and an unexpected bucket fails with the expected error and logData", t, func() {
+		otherBucket := "otherBucket"
+		logData, err := u.ValidateInput(&s3manager.UploadInput{
+			Key:    &testS3Key,
+			Bucket: &otherBucket,
+		})
+
+		So(err, ShouldResemble, errors.New("unexpected bucket name provided in upload input"))
+		So(logData, ShouldResemble, log.Data{
+			"bucket_name":       testBucket,
+			"input_bucket_name": otherBucket,
+			"s3_key":            testS3Key,
 		})
 	})
 }


### PR DESCRIPTION
### What

- Add `UploadWithPSKAndContext` to uploader, so that an encrypted upload can be cancelled via the context.
- Copied s3crypto file to this repo, modify UploadWithPSK to accept a context, and removed dependency from go.mod
- Improved validation code
- Improved testing code

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone (suggested @redhug1 because he will need the new functionality)