### PR TITLE
Returning a specific error (ErrChuckTooSmall) from uploadPart functions when chunk size below 5MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,17 @@ result, err := s3cli.UploadWithPSKAndContext(
     psk,
 )
 ```
-
 #### Multipart Upload
 
-You may use the low-level AWS SDK s3 client [multipart upload](./pload_multipart.go) methods
+You may use the low-level AWS SDK s3 client [multipart upload](./upload_multipart.go) methods
 
  and upload objects using `multipart upload`, which is an AWS SDK functionality to perform uploads in chunks. More information [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html)
+
+##### Chunk Size
+
+The minimum chunk size allowed in [AWS S3 is 5 MegaBytes (MB)](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html)
+if any chunks (excluding the final chunk) are under this size a ErrChunkTooSmall error will be returned from UploadPart
+and UploadPartWithPsk functions when all chunks have been uploaded.
 
 #### URL
 

--- a/error.go
+++ b/error.go
@@ -110,3 +110,16 @@ func NewChunkNumberNotFound(err error, logData map[string]interface{}) *ErrChunk
 		},
 	}
 }
+
+func NewChunkTooSmallError(err error, logData map[string]interface{}) *ErrChunkTooSmall {
+	return &ErrChunkTooSmall{
+		S3Error: S3Error{
+			err:     err,
+			logData: logData,
+		},
+	}
+}
+
+type ErrChunkTooSmall struct {
+	S3Error
+}


### PR DESCRIPTION
### What

Returning a specific error when a chuck is uploaded that is smaller than 5MB enabling consumers to react to the specific error

### How to review

Upload a file with more than one chunk. The first just must be smaller that 5mb. When you upload the final chunk a ErrChuckTooSmall error should be returned

### Who can review

Anyone
