### PR TITLE
Retract tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/ONSdigital/dp-s3/v2
 
 go 1.17
 
+retract (
+	v2.1.0-beta.2 // Contains retractions only
+	[v2.1.0-beta, v2.1.0-beta.1] // Code never made into main and refers to non-released dependencies
+)
+
 require (
 	github.com/ONSdigital/dp-healthcheck v1.6.1
 	github.com/ONSdigital/log.go/v2 v2.4.1


### PR DESCRIPTION
### What

`v2.1.0-beta` and `v2.1.0-beta.1` tags refer to an experimental feature that never made it into main and should not be used
`v2.1.0-beta.2` will be this commit and contain only retractions so to fall back to latest `v2.0.0`

### How to review

👀 

### Who can review

Anyone
